### PR TITLE
Moved checker to a property in Tool, also added a boolean

### DIFF
--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -507,6 +507,15 @@ definitions:
         type: array
         items:
           type: string
+      has_checker:
+        type: boolean
+        description: >-
+          Whether this tool has a checker tool associated with it
+      checker_url:
+        type: string
+        description: >-
+          Optional url to the checker tool that will exit successfully if this
+          tool produced the expected result given test data.
       verified:
         type: boolean
         description: >-
@@ -628,11 +637,6 @@ definitions:
           Optional url to the test JSON used to test this tool. Note that this
           URL should resolve to the raw unwrapped content that would otherwise
           be available in test.
-      test_tool_url:
-        type: string
-        description: >-
-          Optional url to the test workflow that will exit successfully if this
-          workflow produced the expected result given this test data.
   ToolContainerfile:
     type: object
     description: >-

--- a/src/main/resources/swagger/openapi.yaml
+++ b/src/main/resources/swagger/openapi.yaml
@@ -667,6 +667,14 @@ components:
           type: array
           items:
             type: string
+        has_checker:
+          type: boolean
+          description: Whether this tool has a checker tool associated with it
+        checker_url:
+          type: string
+          description: >-
+            Optional url to the checker tool that will exit successfully if this
+            tool produced the expected result given test data.
         verified:
           type: boolean
           description: >-
@@ -790,11 +798,6 @@ components:
             Optional url to the test JSON used to test this tool. Note that this
             URL should resolve to the raw unwrapped content that would otherwise
             be available in test.
-        test_tool_url:
-          type: string
-          description: >-
-            Optional url to the test workflow that will exit successfully if
-            this workflow produced the expected result given this test data.
     ToolContainerfile:
       type: object
       description: >-


### PR DESCRIPTION
Several changes:
- Moved test_tool_url from an optional property of ToolTests to Tool (because it's supposed to have its own set of ToolTests completely unrelated to the current Tool's ToolTests.
- Added a boolean to the quickly show whether a Tool has a checker associated with it
- Avoided using the word "workflow" to make things more consistent with most terms in the schema.