### PR TITLE
Specify unencoded paths are also allowed

### DIFF
--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -262,7 +262,9 @@ paths:
             A relative path to the additional file (same directory or
             subdirectories), for example 'foo.cwl' would return a 'foo.cwl' from
             the same directory as the main descriptor. 'nestedDirectory/foo.cwl'
-            would return the file  from a nested subdirectory
+            would return the file  from a nested subdirectory.  Unencoded paths
+            such 'sampleDirectory/foo.cwl' should also be allowed
+          pattern: .+
       responses:
         '200':
           description: The tool descriptor.

--- a/src/main/resources/swagger/openapi.yaml
+++ b/src/main/resources/swagger/openapi.yaml
@@ -323,9 +323,11 @@ paths:
             A relative path to the additional file (same directory or
             subdirectories), for example 'foo.cwl' would return a 'foo.cwl' from
             the same directory as the main descriptor. 'nestedDirectory/foo.cwl'
-            would return the file  from a nested subdirectory
+            would return the file  from a nested subdirectory.  Unencoded paths
+            such 'sampleDirectory/foo.cwl' should also be allowed
           schema:
             type: string
+            pattern: .+
       responses:
         '200':
           description: The tool descriptor.


### PR DESCRIPTION
Part of #20 .  Specify that unencoded paths are also allowed as the {relative_path}

Note that swagger codegen 2.3.1 may not generate appropriate files to allow unencoded path parameters.  See https://github.com/swagger-api/swagger-codegen/issues/7688 for similar issue.

Additionally, https://github.com/OAI/OpenAPI-Specification/issues/1288#issuecomment-342539281 seems to indicate that both OpenAPI3 and RFC seems to dissuade the use of reserved set characters in path parameters. 