### PR TITLE
Feature/standardize files

### DIFF
--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -616,7 +616,8 @@ definitions:
     type: string
     description: >-
       The type of descriptor that represents this version of the tool (e.g. CWL,
-      WDL, or NFL).
+      WDL, or NFL). Note that these files can also include associated Docker/container files 
+      and test parameters that further describe a version of a tool
     enum:
       - CWL
       - WDL
@@ -629,7 +630,7 @@ definitions:
     properties:
       type:
         $ref: '#/definitions/DescriptorType'
-      content:
+      descriptor:
         type: string
         description: The descriptor that represents this version of the tool.
       url:
@@ -645,6 +646,8 @@ definitions:
       A tool document that describes how to test with one or more sample test
       JSON.
     properties:
+      type:
+        $ref: '#/definitions/DescriptorType'
       content:
         type: string
         description: >-
@@ -665,6 +668,8 @@ definitions:
     required:
       - containerfile
     properties:
+      type:
+        $ref: '#/definitions/DescriptorType'
       content:
         type: string
         description: The container specification for this tool.

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -630,7 +630,7 @@ definitions:
     properties:
       type:
         $ref: '#/definitions/DescriptorType'
-      descriptor:
+      content:
         type: string
         description: The descriptor that represents this version of the tool.
       url:

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -629,7 +629,7 @@ definitions:
     properties:
       type:
         $ref: '#/definitions/DescriptorType'
-      descriptor:
+      content:
         type: string
         description: The descriptor that represents this version of the tool.
       url:
@@ -645,7 +645,7 @@ definitions:
       A tool document that describes how to test with one or more sample test
       JSON.
     properties:
-      test:
+      content:
         type: string
         description: >-
           Optional test JSON content for this tool. (Note that one of test and
@@ -665,7 +665,7 @@ definitions:
     required:
       - containerfile
     properties:
-      containerfile:
+      content:
         type: string
         description: The container specification for this tool.
       url:

--- a/src/main/resources/swagger/openapi.yaml
+++ b/src/main/resources/swagger/openapi.yaml
@@ -796,7 +796,7 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/DescriptorType'
-        descriptor:
+        content:
           type: string
           description: The descriptor that represents this version of the tool.
         url:
@@ -812,7 +812,7 @@ components:
         A tool document that describes how to test with one or more sample test
         JSON.
       properties:
-        test:
+        content:
           type: string
           description: >-
             Optional test JSON content for this tool. (Note that one of test and
@@ -832,7 +832,7 @@ components:
       required:
         - containerfile
       properties:
-        containerfile:
+        content:
           type: string
           description: The container specification for this tool.
         url:

--- a/src/main/resources/swagger/openapi.yaml
+++ b/src/main/resources/swagger/openapi.yaml
@@ -798,7 +798,7 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/DescriptorType'
-        descriptor:
+        content:
           type: string
           description: The descriptor that represents this version of the tool.
         url:

--- a/src/main/resources/swagger/openapi.yaml
+++ b/src/main/resources/swagger/openapi.yaml
@@ -781,7 +781,9 @@ components:
       type: string
       description: >-
         The type of descriptor that represents this version of the tool (e.g.
-        CWL, WDL, or NFL).
+        CWL, WDL, or NFL). Note that these files can also include associated
+        Docker/container files  and test parameters that further describe a
+        version of a tool
       enum:
         - CWL
         - WDL
@@ -796,7 +798,7 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/DescriptorType'
-        content:
+        descriptor:
           type: string
           description: The descriptor that represents this version of the tool.
         url:
@@ -812,6 +814,8 @@ components:
         A tool document that describes how to test with one or more sample test
         JSON.
       properties:
+        type:
+          $ref: '#/components/schemas/DescriptorType'
         content:
           type: string
           description: >-
@@ -832,6 +836,8 @@ components:
       required:
         - containerfile
       properties:
+        type:
+          $ref: '#/components/schemas/DescriptorType'
         content:
           type: string
           description: The container specification for this tool.


### PR DESCRIPTION
This does some cleanup, making it easier to work with the relative files endpoint by standardizing file fields between container files, descriptors, and tests