### PR TITLE
Feature/link check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,25 @@ language: node_js
 node_js:
   - "lts/*"
 
-install:
-  - npm i -g swagger2openapi
-  - npm i -g markdown-link-check
-
-script:
-  - markdown-link-check ./README.md
-  - swagger2openapi src/main/resources/swagger/ga4gh-tool-discovery.yaml -o src/main/resources/swagger/openapi.yaml
-
-before_install:
-  - openssl aes-256-cbc -K $encrypted_f356a5c69655_key -iv $encrypted_f356a5c69655_iv -in github_deploy_key.enc -out github_deploy_key -d
-
-after_success:
-  - eval "$(ssh-agent)"
-  - chmod 600 github_deploy_key 
-  - ssh-add github_deploy_key
-  - git checkout -B ${TRAVIS_BRANCH}
-  - git add src/main/resources/swagger/openapi.yaml
-  - git commit -m "OpenAPI changed"
-  - echo "Pushing changes"
-  - git push git@github.com:ga4gh/tool-registry-service-schemas ${TRAVIS_BRANCH}
+script: echo "overriding test"
+  
+jobs:
+  include:
+    - stage: check-links
+      install: npm i -g markdown-link-check
+      script: markdown-link-check ./README.md
+    - stage: commit-OpenAPI
+      install: npm i -g swagger2openapi
+      script: 
+        - openssl aes-256-cbc -K $encrypted_f356a5c69655_key -iv $encrypted_f356a5c69655_iv -in github_deploy_key.enc -out github_deploy_key -d
+        - swagger2openapi src/main/resources/swagger/ga4gh-tool-discovery.yaml -o src/main/resources/swagger/openapi.yaml
+      after_success:
+        - eval "$(ssh-agent)"
+        - chmod 600 github_deploy_key 
+        - ssh-add github_deploy_key
+        - git checkout -B ${TRAVIS_BRANCH}
+        - git add src/main/resources/swagger/openapi.yaml
+        - git commit -m "OpenAPI changed"
+        - echo "Pushing changes"
+        - git push git@github.com:ga4gh/tool-registry-service-schemas ${TRAVIS_BRANCH}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
   - "lts/*"
 
-script: echo "overriding test"
-  
 jobs:
   include:
     - stage: check-links
@@ -12,15 +10,8 @@ jobs:
     - stage: commit-OpenAPI
       install: npm i -g swagger2openapi
       script: 
-        - openssl aes-256-cbc -K $encrypted_f356a5c69655_key -iv $encrypted_f356a5c69655_iv -in github_deploy_key.enc -out github_deploy_key -d
         - swagger2openapi src/main/resources/swagger/ga4gh-tool-discovery.yaml -o src/main/resources/swagger/openapi.yaml
       after_success:
-        - eval "$(ssh-agent)"
-        - chmod 600 github_deploy_key 
-        - ssh-add github_deploy_key
         - git checkout -B ${TRAVIS_BRANCH}
-        - git add src/main/resources/swagger/openapi.yaml
-        - git commit -m "OpenAPI changed"
-        - echo "Pushing changes"
-        - git push git@github.com:ga4gh/tool-registry-service-schemas ${TRAVIS_BRANCH}
+        - bash deploy.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ node_js:
 
 install:
   - npm i -g swagger2openapi
+  - npm i -g markdown-link-check
 
 script:
+  - markdown-link-check ./README.md
   - swagger2openapi src/main/resources/swagger/ga4gh-tool-discovery.yaml -o src/main/resources/swagger/openapi.yaml
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Schemas for the GA4GH Tool Registry API
 
 This repository is the home for the schema for the GA4GH Tool Registry API.  The goal of the API is to provide a standardized way to describe the availability of tools and workflows.  In this way, we can have multiple repositories that share Docker-based tools and WDL/CWL-based workflows and have a consistent way to interact, search, and retrieve information from these various registries.  The end goal is to make it much easier to share scientific tools and workflows, enhancing our ability to make research reproducible, sharable, and transparent.
 
-**[View in the Swagger Editor](https://editor2.swagger.io/#!/?import=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/src/main/resources/swagger/ga4gh-tool-discovery.yaml).**  *Manually load the JSON if working from a non-develop branch version.*
+**[View in the Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/src/main/resources/swagger/ga4gh-tool-discovery.yaml).**  *Manually load the JSON if working from a non-develop branch version.*
 
 The [Global Alliance for Genomics and Health](http://genomicsandhealth.org/) (GA4GH) is an international
 coalition, formed to enable the sharing of genomic and clinical data.
@@ -43,7 +43,7 @@ Outstanding questions:
 How to view
 ------------
 
-See the swagger editor to view our [schema in progress](http://editor.swagger.io/#/?import=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/src/main/resources/swagger/ga4gh-tool-discovery.yaml).
+See the swagger editor to view our [schema in progress](https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/src/main/resources/swagger/ga4gh-tool-discovery.yaml).
 
 
 How to contribute changes
@@ -79,8 +79,6 @@ For more information
 --------------------
 
 * http://genomicsandhealth.org/
-* [INSTALL.md](INSTALL.md)
-* [CONTRIBUTING.md](CONTRIBUTING.md)
 * [LICENSE](LICENSE)
 * [Google Groups - old](https://groups.google.com/forum/#!forum/ga4gh-dwg-containers-workflows)
 * [Google Groups - new](https://groups.google.com/a/genomicsandhealth.org/forum/#!forum/ga4gh-dwg-containers-workflows)

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,18 @@
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o xtrace
+
+if ! git diff --exit-code src/main/resources/swagger/openapi.yaml
+  then
+    git diff src/main/resources/swagger/openapi.yaml
+    openssl aes-256-cbc -K $encrypted_f356a5c69655_key -iv $encrypted_f356a5c69655_iv -in github_deploy_key.enc -out github_deploy_key -d
+    eval "$(ssh-agent)"
+    chmod 600 github_deploy_key
+    ssh-add github_deploy_key
+    git add src/main/resources/swagger/openapi.yaml
+    git commit -m "OpenAPI changed"
+    echo "Pushing changes"
+    git push git@github.com:ga4gh/tool-registry-service-schemas ${TRAVIS_BRANCH}
+fi
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -o errexit
 set -o pipefail
 set -o nounset


### PR DESCRIPTION
Basic link check for the README.md + basic fixes to pass it 

Adjusted for https://github.com/swagger-api/swagger-editor/issues/1352

Moves deploy OpenAPI to another stage so that it lets forked repo make PRs without auto-failing on changes unrelated to OpenAPI.  

If someone is making OpenAPI-related changes from forked repo, they can manually change the OpenAPI.yaml with the `git diff` output shown in the failed Travis build logs to prevent the deploy script from executing.