### PR TITLE
Allow description of tool inputs

### DIFF
--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -640,6 +640,9 @@ definitions:
         type: string
         description: The in-language expression used to evaluate a default value for this parameter, if
           none is supplied.
+      documentation:
+        type: string
+        description: Documentation for this parameter provided in the tool descriptor file.
   ValueType:
     description: The type expected for a given value.
     type: object

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -623,11 +623,15 @@ definitions:
     type: object
     description: >-
       An input parameter for a tool or workflow.
+    required:
+      - name
+      - valueType
+      - optional
     properties:
       name:
         type: string
         description: The name of this input value (formatted as expected by the tool)
-      valuetype:
+      valueType:
         $ref: '#/definitions/ValueType'
       optional:
         type: boolean
@@ -637,57 +641,40 @@ definitions:
         description: The in-language expression used to evaluate a default value for this parameter, if
           none is supplied.
   ValueType:
+    description: The type expected for a given value.
     type: object
-    description: The type expected for a given input or output value.
-    enum:
-      - String
-      - Int
-      - Float
-      - Boolean
-      - File
-      - Directory
-      - $ref: '#/definitions/OptionalValueType'
-      - $ref: '#/definitions/ArrayValueType'
-      - $ref: '#/definitions/MapValueType'
-      - $ref: '#/definitions/TupleValueType'
-      - $ref: '#/definitions/ObjectValueType'
-  OptionalValueType:
-    type: object
-    description: A value of another type which may also be null.
+    required:
+      - valueType
+    maxProperties: 2
     properties:
+      valueType:
+        type: string
+        description: The type of this value
+        enum:
+          - String
+          - File
+          - Directory
+          - Float
+          - Int
+          - Boolean
+          - Array
+          - Tuple
+          - Map
+          - Object
       optionalType:
         $ref: '#/definitions/ValueType'
-  ArrayValueType:
-    type: object
-    description: A value of arrays of another type.
-    properties:
       arrayType:
         $ref: '#/definitions/ValueType'
-  MapValueType:
-    type: object
-    description: A type representing a map from one type to another.
-    properties:
-      keyType:
-        $ref: '#/definitions/ValueType'
-      valueType:
-        $ref: '#/definitions/ValueType'
-  TupleValueType:
-    type: object
-    description: A type representing a map from one type to another.
-    properties:
+      mapType:
+        $ref: '#/definitions/MapValueType'
       tupleTypes:
         type: array
         items:
           $ref: '#/definitions/ValueType'
-  ObjectValueType:
-    type: object
-    description: A type representing a map from one type to another.
-    properties:
-      fields:
+      objectFieldTypes:
         type: array
         items:
           type: object
-          description: A field within an object
           properties:
             fieldName:
               type: string
@@ -695,6 +682,18 @@ definitions:
               type: array
               items:
                 $ref: '#/definitions/ToolParameter'
+  MapValueType:
+    type: object
+    description: A type representing a map from one type to another.
+    required:
+      - keyType
+      - valueType
+    properties:
+      keyType:
+        $ref: '#/definitions/ValueType'
+      valueType:
+        $ref: '#/definitions/ValueType'
+
   DescriptorType:
     type: string
     description: >-

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -614,6 +614,87 @@ definitions:
         description: >-
           Source of metadata that can support a verified tool, such as an email
           or URL
+      inputs:
+        description: A list of inputs for this tool
+        type: array
+        items:
+          $ref: '#/definitions/ToolParameter'
+  ToolParameter:
+    type: object
+    description: >-
+      An input parameter for a tool or workflow.
+    properties:
+      name:
+        type: string
+        description: The name of this input value (formatted as expected by the tool)
+      valuetype:
+        $ref: '#/definitions/ValueType'
+      optional:
+        type: boolean
+        description: Whether the tool allows this value to not be specified
+      default:
+        type: string
+        description: The in-language expression used to evaluate a default value for this parameter, if
+          none is supplied.
+  ValueType:
+    type: object
+    description: The type expected for a given input or output value.
+    enum:
+      - String
+      - Int
+      - Float
+      - Boolean
+      - File
+      - Directory
+      - $ref: '#/definitions/OptionalValueType'
+      - $ref: '#/definitions/ArrayValueType'
+      - $ref: '#/definitions/MapValueType'
+      - $ref: '#/definitions/TupleValueType'
+      - $ref: '#/definitions/ObjectValueType'
+  OptionalValueType:
+    type: object
+    description: A value of another type which may also be null.
+    properties:
+      optionalType:
+        $ref: '#/definitions/ValueType'
+  ArrayValueType:
+    type: object
+    description: A value of arrays of another type.
+    properties:
+      arrayType:
+        $ref: '#/definitions/ValueType'
+  MapValueType:
+    type: object
+    description: A type representing a map from one type to another.
+    properties:
+      keyType:
+        $ref: '#/definitions/ValueType'
+      valueType:
+        $ref: '#/definitions/ValueType'
+  TupleValueType:
+    type: object
+    description: A type representing a map from one type to another.
+    properties:
+      tupleTypes:
+        type: array
+        items:
+          $ref: '#/definitions/ValueType'
+  ObjectValueType:
+    type: object
+    description: A type representing a map from one type to another.
+    properties:
+      fields:
+        type: array
+        items:
+          type: object
+          description: A field within an object
+          properties:
+            fieldName:
+              type: string
+            fieldDescription:
+              type: array
+              items:
+                $ref: '#/definitions/ToolParameter'
   DescriptorType:
     type: string
     description: >-

--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -657,6 +657,7 @@ definitions:
           - Float
           - Int
           - Boolean
+          - Optional
           - Array
           - Tuple
           - Map


### PR DESCRIPTION
This is an attempt to add a field for describing tool inputs as part of the `ToolVersion` description.

(Note: plenty of iteration is possible here of course so feedback is welcome!)
(Note: if this generally gets a thumbs-up, I'll transcribe into the OpenAPI 3.0 version)