### PR TITLE
Update BasePath

### DIFF
--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -18,7 +18,7 @@ info:
 produces:
   - application/json
   - text/plain
-basePath: /api/ga4gh/v2
+basePath: /ga4gh/trs/v2
 tags:
   - name: GA4GH
     description: A set of resources proposed as a common standard for tool repositories


### PR DESCRIPTION
Linked to issue #71: Updated base path to `basePath: `/ga4gh/trs/v2`