### PR TITLE
Attempt to fix tooling

### DIFF
--- a/scripts/update-ghpages.sh
+++ b/scripts/update-ghpages.sh
@@ -8,6 +8,8 @@ BRANCH=$(echo "$TRAVIS_BRANCH" | awk '{print tolower($0)}')
 BRANCH_PATH="preview/$BRANCH"
 git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
 git fetch origin gh-pages
+#TODO: changes in the package-lock.json are breaking the build, see https://api.travis-ci.org/v3/job/544918298/log.txt
+git checkout package-lock.json
 git checkout gh-pages
 rm -rf "${BRANCH_PATH}"
 mkdir -p "${BRANCH_PATH}"


### PR DESCRIPTION
Trying to fix build for "Latest V2 API release from the develop branch:"

Currently results in 
```
error: Your local changes to the following files would be overwritten by checkout:
	package-lock.json
Please commit your changes or stash them before you switch branches.
Aborting
```
and the build succeeds(?) without deploying anything for develop. 
