### PR TITLE
PRC feedback - strict tool versioning for reproducibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ dist: xenial
 language: java
 jdk: openjdk8
 
+# looks like papa32 plugin 1.5.0 is no longer compatible with gradle 5, the other option is to try running without it
+before_install:
+  - wget http://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+  - unzip -qq gradle-4.10.2-bin.zip
+  - export GRADLE_HOME=$PWD/gradle-4.10.2
+  - export PATH=$GRADLE_HOME/bin:$PATH
+  - gradle -v
+
 jobs:
   include:
     - stage: check-links

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -92,7 +92,9 @@ paths:
           type: string
           description: >-
             An identifier of the tool version, scoped to this registry, for
-            example `v1`.
+            example `v1`. We recommend that versions use semantic versioning https://semver.org/spec/v2.0.0.html 
+            (For example, `1.0.0` instead of `develop`)
+            
       responses:
         '200':
           description: A tool version.

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -589,6 +589,11 @@ definitions:
           An identifier of the version of this tool for this particular tool
           registry.
         example: v1
+      immutable:
+        type: boolean
+        description: >-
+          This version of a tool is guaranteed to not change over time (as opposed to a 
+          tool build from a develop or master branch in git).
       images:
         description: >-
           All known docker images (and versions/hashes) used by this tool. If
@@ -643,6 +648,11 @@ definitions:
       updated:
         type: string
         description: Last time the container was updated.
+      hashcode:
+        type: string
+        description: Helpful for immutable tool versions, but can be independent. This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
+        example: 
+          - 'sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182'
       image_type:
         $ref: '#/definitions/ImageType'
   ImageType:

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -446,6 +446,21 @@ paths:
             items:
               $ref: '#/definitions/ToolClass'
 definitions:
+  Checksum:
+    type: object
+    required: ['checksum', 'type']
+    properties:
+      checksum:
+        type: string
+        description: |-
+          The hex-string encoded checksum for the data. 
+      type:
+        type: string
+        description: |-
+          The digest method used to create the checksum.
+          The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-hash-alg-registry/blob/master/hash-alg.csv[GA4GH Hash Algorithm Registry].
+          Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920].
+          GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future.
   ToolFile:
     type: object
     properties:
@@ -596,7 +611,7 @@ definitions:
         description: >-
           This version of a tool is guaranteed to not change over time (for example, a 
           tool built from a tag in git as opposed to a branch). A production quality tool 
-          is required to have a hashcode
+          is required to have a checksum
       images:
         description: >-
           All known docker images (and versions/hashes) used by this tool. If
@@ -651,13 +666,16 @@ definitions:
       updated:
         type: string
         description: Last time the container was updated.
-      hashcode:
-        type: string
+      checksum:
+        type: array
+        items:
+          $ref: '#/definitions/Checksum'
         description: >- 
           A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. 
           This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
         example: 
-          - 'sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182'
+          - checksum: '77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182' 
+            type: sha256
       image_type:
         $ref: '#/definitions/ImageType'
   ImageType:
@@ -699,11 +717,15 @@ definitions:
       content:
         type: string
         description: The content of the file itself. One of url or content is required.
-      hashcode:
-        type: string
+      checksum:
+        type: array
+        items:
+          $ref: '#/definitions/Checksum'
         description: >- 
-          A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes.
-          This exposes a hashcode for specific files to verify whether the file has changed.
+          A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. 
+        example:
+          - checksum: ea2a5db69bd20a42976838790bc29294df3af02b
+            type: sha1
       url:
         type: string
         description: >-

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -591,11 +591,12 @@ definitions:
           An identifier of the version of this tool for this particular tool
           registry.
         example: v1
-      immutable:
+      is_production:
         type: boolean
         description: >-
           This version of a tool is guaranteed to not change over time (for example, a 
-          tool built from a tag in git as opposed to a branch).
+          tool built from a tag in git as opposed to a branch). A production quality tool 
+          is required to have a hashcode
       images:
         description: >-
           All known docker images (and versions/hashes) used by this tool. If
@@ -653,7 +654,8 @@ definitions:
       hashcode:
         type: string
         description: >- 
-          Helpful for immutable tool versions, but can be useful in other cases as well. This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
+          A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. 
+          This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
         example: 
           - 'sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182'
       image_type:
@@ -700,7 +702,8 @@ definitions:
       hashcode:
         type: string
         description: >- 
-          Helpful for immutable tool versions, but can be useful in other cases as well. This exposes a hashcode for specific files to verify whether the file has changed.
+          A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes.
+          This exposes a hashcode for specific files to verify whether the file has changed.
       url:
         type: string
         description: >-

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -697,6 +697,10 @@ definitions:
       content:
         type: string
         description: The content of the file itself. One of url or content is required.
+      hashcode:
+        type: string
+        description: >- 
+          Helpful for immutable tool versions, but can be useful in other cases as well. This exposes a hashcode for specific files to verify whether the file has changed.
       url:
         type: string
         description: >-

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -594,8 +594,8 @@ definitions:
       immutable:
         type: boolean
         description: >-
-          This version of a tool is guaranteed to not change over time (as opposed to a 
-          tool build from a develop or master branch in git).
+          This version of a tool is guaranteed to not change over time (for example, a 
+          tool built from a tag in git as opposed to a branch).
       images:
         description: >-
           All known docker images (and versions/hashes) used by this tool. If
@@ -652,7 +652,8 @@ definitions:
         description: Last time the container was updated.
       hashcode:
         type: string
-        description: Helpful for immutable tool versions, but can be independent. This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
+        description: >- 
+          Helpful for immutable tool versions, but can be useful in other cases as well. This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
         example: 
           - 'sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182'
       image_type:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -713,8 +713,8 @@ components:
           example: v1
         immutable:
           type: boolean
-          description: This version of a tool is guaranteed to not change over time (as
-            opposed to a  tool build from a develop or master branch in git).
+          description: This version of a tool is guaranteed to not change over time (for
+            example, a  tool built from a tag in git as opposed to a branch).
         images:
           description: All known docker images (and versions/hashes) used by this tool. If
             the tool has to evaluate any of the docker images strings at
@@ -766,10 +766,10 @@ components:
           description: Last time the container was updated.
         hashcode:
           type: string
-          description: Helpful for immutable tool versions, but can be independent. This
-            exposes the hashcode for specific image versions to verify that the
-            container version pulled is actually the version that was indexed by
-            the registry.
+          description: Helpful for immutable tool versions, but can be useful in other
+            cases as well. This exposes the hashcode for specific image versions
+            to verify that the container version pulled is actually the version
+            that was indexed by the registry.
           example:
             - sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182
         image_type:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -101,7 +101,9 @@ paths:
           in: path
           required: true
           description: An identifier of the tool version, scoped to this registry, for
-            example `v1`.
+            example `v1`. We recommend that versions use semantic versioning
+            https://semver.org/spec/v2.0.0.html  (For example, `1.0.0` instead
+            of `develop`)
           schema:
             type: string
       responses:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -811,6 +811,11 @@ components:
         content:
           type: string
           description: The content of the file itself. One of url or content is required.
+        hashcode:
+          type: string
+          description: Helpful for immutable tool versions, but can be useful in other
+            cases as well. This exposes a hashcode for specific files to verify
+            whether the file has changed.
         url:
           type: string
           description: Optional url to the underlying content, should include version

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -573,6 +573,25 @@ components:
       schema:
         type: string
   schemas:
+    Checksum:
+      type: object
+      required:
+        - checksum
+        - type
+      properties:
+        checksum:
+          type: string
+          description: "The hex-string encoded checksum for the data. "
+        type:
+          type: string
+          description: >-
+            The digest method used to create the checksum.
+
+            The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-hash-alg-registry/blob/master/hash-alg.csv[GA4GH Hash Algorithm Registry].
+
+            Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920].
+
+            GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future.
     ToolFile:
       type: object
       properties:
@@ -715,7 +734,7 @@ components:
           type: boolean
           description: This version of a tool is guaranteed to not change over time (for
             example, a  tool built from a tag in git as opposed to a branch). A
-            production quality tool  is required to have a hashcode
+            production quality tool  is required to have a checksum
         images:
           description: All known docker images (and versions/hashes) used by this tool. If
             the tool has to evaluate any of the docker images strings at
@@ -765,15 +784,18 @@ components:
         updated:
           type: string
           description: Last time the container was updated.
-        hashcode:
-          type: string
+        checksum:
+          type: array
+          items:
+            $ref: "#/components/schemas/Checksum"
           description: A production (immutable) tool version is required to have a
             hashcode. Not required otherwise, but might be useful to detect
             changes.  This exposes the hashcode for specific image versions to
             verify that the container version pulled is actually the version
             that was indexed by the registry.
           example:
-            - sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182
+            - checksum: 77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182
+              type: sha256
         image_type:
           $ref: "#/components/schemas/ImageType"
     ImageType:
@@ -813,12 +835,16 @@ components:
         content:
           type: string
           description: The content of the file itself. One of url or content is required.
-        hashcode:
-          type: string
-          description: A production (immutable) tool version is required to have a
+        checksum:
+          type: array
+          items:
+            $ref: "#/components/schemas/Checksum"
+          description: "A production (immutable) tool version is required to have a
             hashcode. Not required otherwise, but might be useful to detect
-            changes. This exposes a hashcode for specific files to verify
-            whether the file has changed.
+            changes. "
+          example:
+            - checksum: ea2a5db69bd20a42976838790bc29294df3af02b
+              type: sha1
         url:
           type: string
           description: Optional url to the underlying content, should include version

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -711,10 +711,11 @@ components:
           description: An identifier of the version of this tool for this particular tool
             registry.
           example: v1
-        immutable:
+        is_production:
           type: boolean
           description: This version of a tool is guaranteed to not change over time (for
-            example, a  tool built from a tag in git as opposed to a branch).
+            example, a  tool built from a tag in git as opposed to a branch). A
+            production quality tool  is required to have a hashcode
         images:
           description: All known docker images (and versions/hashes) used by this tool. If
             the tool has to evaluate any of the docker images strings at
@@ -766,9 +767,10 @@ components:
           description: Last time the container was updated.
         hashcode:
           type: string
-          description: Helpful for immutable tool versions, but can be useful in other
-            cases as well. This exposes the hashcode for specific image versions
-            to verify that the container version pulled is actually the version
+          description: A production (immutable) tool version is required to have a
+            hashcode. Not required otherwise, but might be useful to detect
+            changes.  This exposes the hashcode for specific image versions to
+            verify that the container version pulled is actually the version
             that was indexed by the registry.
           example:
             - sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182
@@ -813,8 +815,9 @@ components:
           description: The content of the file itself. One of url or content is required.
         hashcode:
           type: string
-          description: Helpful for immutable tool versions, but can be useful in other
-            cases as well. This exposes a hashcode for specific files to verify
+          description: A production (immutable) tool version is required to have a
+            hashcode. Not required otherwise, but might be useful to detect
+            changes. This exposes a hashcode for specific files to verify
             whether the file has changed.
         url:
           type: string

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -709,6 +709,10 @@ components:
           description: An identifier of the version of this tool for this particular tool
             registry.
           example: v1
+        immutable:
+          type: boolean
+          description: This version of a tool is guaranteed to not change over time (as
+            opposed to a  tool build from a develop or master branch in git).
         images:
           description: All known docker images (and versions/hashes) used by this tool. If
             the tool has to evaluate any of the docker images strings at
@@ -758,6 +762,14 @@ components:
         updated:
           type: string
           description: Last time the container was updated.
+        hashcode:
+          type: string
+          description: Helpful for immutable tool versions, but can be independent. This
+            exposes the hashcode for specific image versions to verify that the
+            container version pulled is actually the version that was indexed by
+            the registry.
+          example:
+            - sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182
         image_type:
           $ref: "#/components/schemas/ImageType"
     ImageType:


### PR DESCRIPTION
This is the compromise that I'm proposing for the PRC feedback for tool versioning. 

This should open the possibility of implementations providing/indexing immutable tool versions only. 
However, it doesn't restrict us only to implementations that provide immutable versions.  

FYI @DCGenomics @junjun-zhang @rishidev 