### PR TITLE
PRC feedback - CURIE-like prefixes

### DIFF
--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -497,7 +497,8 @@ definitions:
         type: string
         example: dockstore:123456
         description: >- 
-          A unique identifier of the tool, scoped to this registry with a CURIE-like prefix. See https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json for the current list of prefixes and the registry that they correspond to. TRS IDs are strings made up of uppercase and lowercase letters, one colon, decimal digits, hyphen, period, percent, underscore and tilde ([A-Za-z0-9.-_~%])+:[A-Za-z0-9.-_~%]+ to support CURIE-like prefixes. Special characters like slashes can be encoded to work within these restrictions.
+          A unique identifier of the tool, scoped to this registry with a CURIE-like prefix. See https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json for the current list of prefixes and the registry that they correspond to. TRS IDs are strings made up of uppercase and lowercase letters, one colon, decimal digits, hyphen, period, underscore and tilde ([A-Za-z0-9.-_~])+:[A-Za-z0-9.-_~]+ to support CURIE-like prefixes. Special characters like slashes can be percent encoded to work within these restrictions.
+          This is based on https://tools.ietf.org/html/rfc3986#section-3.3 which includes a discussion on valid "path components."
       aliases:
         type: array
         items:

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -38,8 +38,8 @@ paths:
           required: true
           type: string
           description: >-
-            A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
+            example `dockstore:123456`.
       responses:
         '200':
           description: A tool.
@@ -62,8 +62,8 @@ paths:
           required: true
           type: string
           description: >-
-            A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
+            example `dockstore:123456`.
       responses:
         '200':
           description: An array of tool versions.
@@ -84,8 +84,8 @@ paths:
           required: true
           type: string
           description: >-
-            A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
+            example `dockstore:123456`.
         - name: version_id
           in: path
           required: true
@@ -211,8 +211,8 @@ paths:
         - name: id
           in: path
           description: >-
-            A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
+            example `dockstore:123456`.
           required: true
           type: string
         - name: version_id
@@ -259,8 +259,8 @@ paths:
         - name: id
           in: path
           description: >-
-            A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
+            example `dockstore:123456`.
           required: true
           type: string
         - name: version_id
@@ -313,8 +313,8 @@ paths:
         - name: id
           in: path
           description: >-
-            A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
+            example `dockstore:123456`.
           required: true
           type: string
         - name: version_id
@@ -357,8 +357,8 @@ paths:
         - name: id
           in: path
           description: >-
-            A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
+            example `dockstore:123456`.
           required: true
           type: string
         - name: version_id
@@ -394,8 +394,8 @@ paths:
         - name: id
           in: path
           description: >-
-            A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
+            example `dockstore:123456`.
           required: true
           type: string
         - name: version_id
@@ -495,8 +495,9 @@ definitions:
         description: The URL for this tool in this registry.
       id:
         type: string
-        example: 123456
-        description: 'A unique identifier of the tool, scoped to this registry.'
+        example: dockstore:123456
+        description: >- 
+          A unique identifier of the tool, scoped to this registry with a CURIE-like prefix. See https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json for the current list of prefixes and the registry that they correspond to. TRS IDs are strings made up of uppercase and lowercase letters, decimal digits, hypen, period, percent, underscore and tilde [A-Za-z0-9.-%_~] to simplify parsing CURIE-like prefixes. Special characters like slashes can be encoded to work with these restrictions.
       aliases:
         type: array
         items:

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -497,7 +497,7 @@ definitions:
         type: string
         example: dockstore:123456
         description: >- 
-          A unique identifier of the tool, scoped to this registry with a CURIE-like prefix. See https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json for the current list of prefixes and the registry that they correspond to. TRS IDs are strings made up of uppercase and lowercase letters, decimal digits, hyphen, period, percent, underscore and tilde [A-Za-z0-9.-%_~] to simplify parsing CURIE-like prefixes. Special characters like slashes can be encoded to work within these restrictions.
+          A unique identifier of the tool, scoped to this registry with a CURIE-like prefix. See https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json for the current list of prefixes and the registry that they correspond to. TRS IDs are strings made up of uppercase and lowercase letters, one colon, decimal digits, hyphen, period, percent, underscore and tilde ([A-Za-z0-9.-_~%])+:[A-Za-z0-9.-_~%]+ to support CURIE-like prefixes. Special characters like slashes can be encoded to work within these restrictions.
       aliases:
         type: array
         items:

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -38,8 +38,8 @@ paths:
           required: true
           type: string
           description: >-
-            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
-            example `dockstore:123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix. An example would be
+            `dockstore:123456`.
       responses:
         '200':
           description: A tool.
@@ -62,8 +62,8 @@ paths:
           required: true
           type: string
           description: >-
-            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
-            example `dockstore:123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix. An example would be
+            `dockstore:123456`.
       responses:
         '200':
           description: An array of tool versions.
@@ -84,8 +84,8 @@ paths:
           required: true
           type: string
           description: >-
-            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
-            example `dockstore:123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix. An example would be
+            `dockstore:123456`.
         - name: version_id
           in: path
           required: true
@@ -116,8 +116,8 @@ paths:
           type: string
           in: query
           description: >-
-            A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix. An example would be
+            `dockstore:123456`.
         - name: alias
           type: string
           in: query
@@ -211,8 +211,8 @@ paths:
         - name: id
           in: path
           description: >-
-            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
-            example `dockstore:123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix. An example would be
+            `dockstore:123456`.
           required: true
           type: string
         - name: version_id
@@ -259,8 +259,8 @@ paths:
         - name: id
           in: path
           description: >-
-            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
-            example `dockstore:123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix. An example would be
+            `dockstore:123456`.
           required: true
           type: string
         - name: version_id
@@ -313,8 +313,8 @@ paths:
         - name: id
           in: path
           description: >-
-            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
-            example `dockstore:123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix. An example would be
+            `dockstore:123456`.
           required: true
           type: string
         - name: version_id
@@ -357,8 +357,8 @@ paths:
         - name: id
           in: path
           description: >-
-            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
-            example `dockstore:123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix. An example would be
+            `dockstore:123456`.
           required: true
           type: string
         - name: version_id
@@ -394,8 +394,8 @@ paths:
         - name: id
           in: path
           description: >-
-            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix for
-            example `dockstore:123456`.
+            A unique identifier of the tool, scoped to this registry, with a CURIE-like prefix. An example would be
+            `dockstore:123456`.
           required: true
           type: string
         - name: version_id
@@ -497,7 +497,7 @@ definitions:
         type: string
         example: dockstore:123456
         description: >- 
-          A unique identifier of the tool, scoped to this registry with a CURIE-like prefix. See https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json for the current list of prefixes and the registry that they correspond to. TRS IDs are strings made up of uppercase and lowercase letters, decimal digits, hypen, period, percent, underscore and tilde [A-Za-z0-9.-%_~] to simplify parsing CURIE-like prefixes. Special characters like slashes can be encoded to work with these restrictions.
+          A unique identifier of the tool, scoped to this registry with a CURIE-like prefix. See https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json for the current list of prefixes and the registry that they correspond to. TRS IDs are strings made up of uppercase and lowercase letters, decimal digits, hyphen, period, percent, underscore and tilde [A-Za-z0-9.-%_~] to simplify parsing CURIE-like prefixes. Special characters like slashes can be encoded to work within these restrictions.
       aliases:
         type: array
         items:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -31,7 +31,7 @@ paths:
           in: path
           required: true
           description: A unique identifier of the tool, scoped to this registry, with a
-            CURIE-like prefix for example `dockstore:123456`.
+            CURIE-like prefix. An example would be `dockstore:123456`.
           schema:
             type: string
       responses:
@@ -65,7 +65,7 @@ paths:
           in: path
           required: true
           description: A unique identifier of the tool, scoped to this registry, with a
-            CURIE-like prefix for example `dockstore:123456`.
+            CURIE-like prefix. An example would be `dockstore:123456`.
           schema:
             type: string
       responses:
@@ -94,7 +94,7 @@ paths:
           in: path
           required: true
           description: A unique identifier of the tool, scoped to this registry, with a
-            CURIE-like prefix for example `dockstore:123456`.
+            CURIE-like prefix. An example would be `dockstore:123456`.
           schema:
             type: string
         - name: version_id
@@ -135,8 +135,8 @@ paths:
       parameters:
         - name: id
           in: query
-          description: A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+          description: A unique identifier of the tool, scoped to this registry, with a
+            CURIE-like prefix. An example would be `dockstore:123456`.
           schema:
             type: string
         - name: alias
@@ -249,7 +249,7 @@ paths:
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, with a
-            CURIE-like prefix for example `dockstore:123456`.
+            CURIE-like prefix. An example would be `dockstore:123456`.
           required: true
           schema:
             type: string
@@ -306,7 +306,7 @@ paths:
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, with a
-            CURIE-like prefix for example `dockstore:123456`.
+            CURIE-like prefix. An example would be `dockstore:123456`.
           required: true
           schema:
             type: string
@@ -369,7 +369,7 @@ paths:
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, with a
-            CURIE-like prefix for example `dockstore:123456`.
+            CURIE-like prefix. An example would be `dockstore:123456`.
           required: true
           schema:
             type: string
@@ -424,7 +424,7 @@ paths:
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, with a
-            CURIE-like prefix for example `dockstore:123456`.
+            CURIE-like prefix. An example would be `dockstore:123456`.
           required: true
           schema:
             type: string
@@ -472,7 +472,7 @@ paths:
         - name: id
           in: path
           description: A unique identifier of the tool, scoped to this registry, with a
-            CURIE-like prefix for example `dockstore:123456`.
+            CURIE-like prefix. An example would be `dockstore:123456`.
           required: true
           schema:
             type: string
@@ -626,10 +626,10 @@ components:
             https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json
             for the current list of prefixes and the registry that they
             correspond to. TRS IDs are strings made up of uppercase and
-            lowercase letters, decimal digits, hypen, period, percent,
+            lowercase letters, decimal digits, hyphen, period, percent,
             underscore and tilde [A-Za-z0-9.-%_~] to simplify parsing CURIE-like
             prefixes. Special characters like slashes can be encoded to work
-            with these restrictions.
+            within these restrictions.
         aliases:
           type: array
           items:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -30,8 +30,8 @@ paths:
         - name: id
           in: path
           required: true
-          description: A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+          description: A unique identifier of the tool, scoped to this registry, with a
+            CURIE-like prefix for example `dockstore:123456`.
           schema:
             type: string
       responses:
@@ -64,8 +64,8 @@ paths:
         - name: id
           in: path
           required: true
-          description: A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+          description: A unique identifier of the tool, scoped to this registry, with a
+            CURIE-like prefix for example `dockstore:123456`.
           schema:
             type: string
       responses:
@@ -93,8 +93,8 @@ paths:
         - name: id
           in: path
           required: true
-          description: A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+          description: A unique identifier of the tool, scoped to this registry, with a
+            CURIE-like prefix for example `dockstore:123456`.
           schema:
             type: string
         - name: version_id
@@ -248,8 +248,8 @@ paths:
             type: string
         - name: id
           in: path
-          description: A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+          description: A unique identifier of the tool, scoped to this registry, with a
+            CURIE-like prefix for example `dockstore:123456`.
           required: true
           schema:
             type: string
@@ -305,8 +305,8 @@ paths:
             type: string
         - name: id
           in: path
-          description: A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+          description: A unique identifier of the tool, scoped to this registry, with a
+            CURIE-like prefix for example `dockstore:123456`.
           required: true
           schema:
             type: string
@@ -368,8 +368,8 @@ paths:
             type: string
         - name: id
           in: path
-          description: A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+          description: A unique identifier of the tool, scoped to this registry, with a
+            CURIE-like prefix for example `dockstore:123456`.
           required: true
           schema:
             type: string
@@ -423,8 +423,8 @@ paths:
             type: string
         - name: id
           in: path
-          description: A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+          description: A unique identifier of the tool, scoped to this registry, with a
+            CURIE-like prefix for example `dockstore:123456`.
           required: true
           schema:
             type: string
@@ -471,8 +471,8 @@ paths:
       parameters:
         - name: id
           in: path
-          description: A unique identifier of the tool, scoped to this registry, for
-            example `123456`.
+          description: A unique identifier of the tool, scoped to this registry, with a
+            CURIE-like prefix for example `dockstore:123456`.
           required: true
           schema:
             type: string
@@ -620,8 +620,16 @@ components:
           description: The URL for this tool in this registry.
         id:
           type: string
-          example: 123456
-          description: A unique identifier of the tool, scoped to this registry.
+          example: dockstore:123456
+          description: A unique identifier of the tool, scoped to this registry with a
+            CURIE-like prefix. See
+            https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json
+            for the current list of prefixes and the registry that they
+            correspond to. TRS IDs are strings made up of uppercase and
+            lowercase letters, decimal digits, hypen, period, percent,
+            underscore and tilde [A-Za-z0-9.-%_~] to simplify parsing CURIE-like
+            prefixes. Special characters like slashes can be encoded to work
+            with these restrictions.
         aliases:
           type: array
           items:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -627,9 +627,11 @@ components:
             for the current list of prefixes and the registry that they
             correspond to. TRS IDs are strings made up of uppercase and
             lowercase letters, one colon, decimal digits, hyphen, period,
-            percent, underscore and tilde ([A-Za-z0-9.-_~%])+:[A-Za-z0-9.-_~%]+
-            to support CURIE-like prefixes. Special characters like slashes can
-            be encoded to work within these restrictions.
+            underscore and tilde ([A-Za-z0-9.-_~])+:[A-Za-z0-9.-_~]+ to support
+            CURIE-like prefixes. Special characters like slashes can be percent
+            encoded to work within these restrictions. This is based on
+            https://tools.ietf.org/html/rfc3986#section-3.3 which includes a
+            discussion on valid "path components."
         aliases:
           type: array
           items:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -626,10 +626,10 @@ components:
             https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json
             for the current list of prefixes and the registry that they
             correspond to. TRS IDs are strings made up of uppercase and
-            lowercase letters, decimal digits, hyphen, period, percent,
-            underscore and tilde [A-Za-z0-9.-%_~] to simplify parsing CURIE-like
-            prefixes. Special characters like slashes can be encoded to work
-            within these restrictions.
+            lowercase letters, one colon, decimal digits, hyphen, period,
+            percent, underscore and tilde ([A-Za-z0-9.-_~%])+:[A-Za-z0-9.-_~%]+
+            to support CURIE-like prefixes. Special characters like slashes can
+            be encoded to work within these restrictions.
         aliases:
           type: array
           items:


### PR DESCRIPTION
There is a section in the PRC document that suggests the use of CURIE-like IDs. 
Our current schema says little about the format for IDs, simply that they should be unique per implementation of a schema. (i.e. IDs uniquely identify tools in a particular registry implementation). 

The PRC feedback is the following:
```
“Id”: value described as “scoped identifier” => but what about requiring CURIEs / properly versioned ids?
Would add value to the service
Core property for all the services for GA4GH
Prefix should be clarified,

“Id” and “name” => possible clashes; so for “labeled ids“ following the { "id": "CURIE", "label": "some_string" } format?

Should tool id (https://github.com/ga4gh/tool-registry-service-schemas/blob/0d36f7199c1c32446127f242406c0214f19c597c/openapi/openapi.yaml#L621-L624) only allow [A-Za-z0-9.-_~] similar to DRS IDs (https://github.com/ga4gh/data-repository-service-schemas/blob/develop/docs/asciidoc/front_matter.adoc#drs-ids)
```

I think this is saying that CURIE like IDs should be mandated for all implementations of TRS resulting in IDs that look like `dockstore:12345` as opposed to the current example of `123456`  https://github.com/ga4gh/tool-registry-service-schemas/blob/2.0.0-beta.3/openapi/ga4gh-tool-discovery.yaml#L498 ) The last note seems to imply that if we go down this route, `:` should be a reserved character to distinguish between the prefix and the actual ID. 

An explanation about the second concern (possible classes for id and name) would be helpful. 
Thanks!