### PR TITLE
Alternative to #94 (prefixes) for discussion

### DIFF
--- a/2.0.0-Data-Model.md
+++ b/2.0.0-Data-Model.md
@@ -12,9 +12,17 @@ We are starting with a read-only API due to potentially different views and appr
 
 Multiple formats for descriptors such as [CWL](https://github.com/common-workflow-language/common-workflow-language) and [WDL](https://github.com/broadinstitute/wdl) are permitted. 
 
-Tools IDs can be prefixed and exchanged in a CURIE-like format instead of URLs to identify both the TRS implementation that they originated from and to provide a stable ID that is forward compatible  (ex: `dockstore:123456323` could resolve to https://dockstore.org/api/ga4gh/v1/tools/123456323, https://dockstore.org/api/ga4gh/trs/v2/tools/123456323, https://dockstore.org/api/ga4gh/trs/v3/tools/123456323, etc.). To define the prefixes and the TRS implementations that they correspond to, we recommend that TRS implementations add themselves to https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json to provide for the possibility of creating a global resolver.
+#### TRS URIs
 
-In the case of private TRS implementations not known to the public, consult the same registry.json to determine a unique prefix to avoid confusion in the case of collisions. 
+For convenience, including potentially when passing content references to a WES server, we define a URI syntax for TRS-accessible content. Strings of the form `trs://<server>/<id>` mean _“you can fetch the content with TRS id `<id>` from the TRS server at `<server>` "_.
+
+For example, if a WES server was asked to process `trs://trs.example.org/123456323`, it would know that it could issue a GET request to `https://trs.example.org/api/ga4gh/trs/v2/tools/123456323` to learn how to fetch that object.
+
+This recommendation is intended to mirror the discussion that went into the [DRS URI scheme](https://ga4gh.github.io/data-repository-service-schemas/preview/develop/docs/#_drs_uris).
+
+For informational purposes, we recommend that TRS implementations add themselves to https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json to provide for the possibility of creating a global indexing service and to allow others to more easily discover a TRS implementation. 
+
+### Misc
 
 The entire schema is shown below, but a more useful form is the Swagger editor to view our [schema in progress](http://editor.swagger.io/#/?import=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/src/main/resources/swagger/ga4gh-tool-discovery.yaml) 
 
@@ -24,6 +32,3 @@ Note that the swagger editor itself can kickstart a project by generating server
 
 * How do we track authorship? Should we track authorship of the tool metadata, the Docker image, or the underlying algorithm, or all of above?
 * What do we need to provide to allow for indexing and external services like an external sparql service.
-* Versioning
-* Terminology discussion (do we describe triples separately from tools? should we describe them as aggregations of tools for just the case that CWL documents have more than one tool? etc.)
-

--- a/2.0.0-Data-Model.md
+++ b/2.0.0-Data-Model.md
@@ -12,7 +12,9 @@ We are starting with a read-only API due to potentially different views and appr
 
 Multiple formats for descriptors such as [CWL](https://github.com/common-workflow-language/common-workflow-language) and [WDL](https://github.com/broadinstitute/wdl) are permitted. 
 
-Tools should have a globally unique identifier which identifies the authoritative source for a tool (ex: 123456323@agora.broadinstitute.org )
+Tools IDs can be prefixed and exchanged in a CURIE-like format instead of URLs to identify both the TRS implementation that they originated from and to provide a stable ID that is forward compatible  (ex: `dockstore:123456323` could resolve to https://dockstore.org/api/ga4gh/v1/tools/123456323, https://dockstore.org/api/ga4gh/trs/v2/tools/123456323, https://dockstore.org/api/ga4gh/trs/v3/tools/123456323, etc. ). To define the prefixes and the TRS implementations that they correspond to, we recommend that TRS implementations add themselves to https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json to provide for the possibility of creating a global resolver.
+
+In the case of private TRS implementations not known to the public, we only recommend consulting the same registry.json to determine a unique prefix to avoid confusion in the case of collisions. 
 
 The entire schema is shown below, but a more useful form is the Swagger editor to view our [schema in progress](http://editor.swagger.io/#/?import=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/src/main/resources/swagger/ga4gh-tool-discovery.yaml) 
 

--- a/2.0.0-Data-Model.md
+++ b/2.0.0-Data-Model.md
@@ -12,9 +12,9 @@ We are starting with a read-only API due to potentially different views and appr
 
 Multiple formats for descriptors such as [CWL](https://github.com/common-workflow-language/common-workflow-language) and [WDL](https://github.com/broadinstitute/wdl) are permitted. 
 
-Tools IDs can be prefixed and exchanged in a CURIE-like format instead of URLs to identify both the TRS implementation that they originated from and to provide a stable ID that is forward compatible  (ex: `dockstore:123456323` could resolve to https://dockstore.org/api/ga4gh/v1/tools/123456323, https://dockstore.org/api/ga4gh/trs/v2/tools/123456323, https://dockstore.org/api/ga4gh/trs/v3/tools/123456323, etc. ). To define the prefixes and the TRS implementations that they correspond to, we recommend that TRS implementations add themselves to https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json to provide for the possibility of creating a global resolver.
+Tools IDs can be prefixed and exchanged in a CURIE-like format instead of URLs to identify both the TRS implementation that they originated from and to provide a stable ID that is forward compatible  (ex: `dockstore:123456323` could resolve to https://dockstore.org/api/ga4gh/v1/tools/123456323, https://dockstore.org/api/ga4gh/trs/v2/tools/123456323, https://dockstore.org/api/ga4gh/trs/v3/tools/123456323, etc.). To define the prefixes and the TRS implementations that they correspond to, we recommend that TRS implementations add themselves to https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json to provide for the possibility of creating a global resolver.
 
-In the case of private TRS implementations not known to the public, we only recommend consulting the same registry.json to determine a unique prefix to avoid confusion in the case of collisions. 
+In the case of private TRS implementations not known to the public, consult the same registry.json to determine a unique prefix to avoid confusion in the case of collisions. 
 
 The entire schema is shown below, but a more useful form is the Swagger editor to view our [schema in progress](http://editor.swagger.io/#/?import=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/src/main/resources/swagger/ga4gh-tool-discovery.yaml) 
 


### PR DESCRIPTION
Based on discussion at BOSC, proposing that CURIE-like IDS are used externally to provide for a potential resolver as opposed to using them internally in the endpoints as IDs

i.e.  `dockstore:123456323` resolves to https://dockstore.org/api/ga4gh/v2/tools/12345 using an external service as opposed to actually having https://dockstore.org/api/ga4gh/v2/tools/dockstore:12345 or https://dockstore.org/api/ga4gh/v2/tools/dockstore%3A12345