### PR TITLE
Optional auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ dist: xenial
 language: java
 jdk: openjdk8
 
+# looks like papa32 plugin 1.5.0 is no longer compatible with gradle 5, the other option is to try running without it
+before_install:
+  - wget http://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+  - unzip -qq gradle-4.10.2-bin.zip
+  - export GRADLE_HOME=$PWD/gradle-4.10.2
+  - export PATH=$GRADLE_HOME/bin:$PATH
+  - gradle -v
+
 jobs:
   include:
     - stage: check-links

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -19,6 +19,11 @@ produces:
   - application/json
   - text/plain
 basePath: /ga4gh/trs/v2
+securityDefinitions: 
+ BEARER: 
+  type: apiKey
+  name: Authorization
+  in: header
 tags:
   - name: GA4GH
     description: A group of web resources proposed as a common standard for tool repositories
@@ -51,6 +56,8 @@ paths:
           description: The tool can not be found.
           schema:
             $ref: '#/definitions/Error'
+      security:
+        - BEARER: []
   '/tools/{id}/versions':
     get:
       summary: List versions of a tool
@@ -73,6 +80,8 @@ paths:
             type: array
             items:
               $ref: '#/definitions/ToolVersion'
+      security:
+        - BEARER: []
   '/tools/{id}/versions/{version_id}':
     get:
       summary: 'List one specific tool version, acts as an anchor for self references'
@@ -104,6 +113,8 @@ paths:
           description: The tool can not be found.
           schema:
             $ref: '#/definitions/Error'
+      security:
+        - BEARER: []
   /tools:
     get:
       summary: List all tools
@@ -191,6 +202,8 @@ paths:
             current_limit:
               description: The current page record limit used for this result.
               type: integer
+      security:
+        - BEARER: []        
   '/tools/{id}/versions/{version_id}/{type}/descriptor':
     get:
       summary: Get the tool descriptor for the specified tool
@@ -233,6 +246,8 @@ paths:
           description: The tool descriptor can not be found.
           schema:
             $ref: '#/definitions/Error'
+      security:
+        - BEARER: []      
   '/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}':
     get:
       summary: Get additional tool descriptor files relative to the main file
@@ -292,6 +307,8 @@ paths:
           description: The tool can not be output in the specified type.
           schema:
             $ref: '#/definitions/Error'
+      security:
+        - BEARER: []      
   '/tools/{id}/versions/{version_id}/{type}/tests':
     get:
       summary: Get a list of test JSONs
@@ -337,6 +354,8 @@ paths:
           description: The tool can not be output in the specified type.
           schema:
             $ref: '#/definitions/Error'
+      security:
+        - BEARER: []
   '/tools/{id}/versions/{version_id}/{type}/files':
     get:
       summary: Get a list of objects that contain the relative path and file type
@@ -381,6 +400,8 @@ paths:
           description: The tool can not be output in the specified type.
           schema:
             $ref: '#/definitions/Error'
+      security:
+        - BEARER: []      
   '/tools/{id}/versions/{version_id}/containerfile':
     get:
       summary: Get the container specification(s) for the specified image.
@@ -418,6 +439,8 @@ paths:
           description: There are no container specifications for this tool.
           schema:
             $ref: '#/definitions/Error'
+      security:
+        - BEARER: []      
   /service-info:
     get:
       summary: Return some information that is useful for describing this registry
@@ -430,6 +453,8 @@ paths:
           description: A ServiceInfo object describing this service.
           schema:
             $ref: '#/definitions/ServiceInfo'
+      security:
+        - BEARER: []      
   /toolClasses:
     get:
       summary: List all tool types
@@ -445,6 +470,8 @@ paths:
             type: array
             items:
               $ref: '#/definitions/ToolClass'
+      security:
+        - BEARER: []        
 definitions:
   ToolFile:
     type: object

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -56,6 +56,8 @@ paths:
             text/plain:
               schema:
                 $ref: "#/components/schemas/Error"
+      security:
+        - BEARER: []
   "/tools/{id}/versions":
     get:
       summary: List versions of a tool
@@ -85,6 +87,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/ToolVersion"
+      security:
+        - BEARER: []
   "/tools/{id}/versions/{version_id}":
     get:
       summary: List one specific tool version, acts as an anchor for self references
@@ -126,6 +130,8 @@ paths:
             text/plain:
               schema:
                 $ref: "#/components/schemas/Error"
+      security:
+        - BEARER: []
   /tools:
     get:
       summary: List all tools
@@ -231,6 +237,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Tool"
+      security:
+        - BEARER: []
   "/tools/{id}/versions/{version_id}/{type}/descriptor":
     get:
       summary: Get the tool descriptor for the specified tool
@@ -282,6 +290,8 @@ paths:
             text/plain:
               schema:
                 $ref: "#/components/schemas/Error"
+      security:
+        - BEARER: []
   "/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}":
     get:
       summary: Get additional tool descriptor files relative to the main file
@@ -350,6 +360,8 @@ paths:
             text/plain:
               schema:
                 $ref: "#/components/schemas/Error"
+      security:
+        - BEARER: []
   "/tools/{id}/versions/{version_id}/{type}/tests":
     get:
       summary: Get a list of test JSONs
@@ -406,6 +418,8 @@ paths:
             text/plain:
               schema:
                 $ref: "#/components/schemas/Error"
+      security:
+        - BEARER: []
   "/tools/{id}/versions/{version_id}/{type}/files":
     get:
       summary: Get a list of objects that contain the relative path and file type
@@ -461,6 +475,8 @@ paths:
             text/plain:
               schema:
                 $ref: "#/components/schemas/Error"
+      security:
+        - BEARER: []
   "/tools/{id}/versions/{version_id}/containerfile":
     get:
       summary: Get the container specification(s) for the specified image.
@@ -509,6 +525,8 @@ paths:
             text/plain:
               schema:
                 $ref: "#/components/schemas/Error"
+      security:
+        - BEARER: []
   /service-info:
     get:
       summary: Return some information that is useful for describing this registry
@@ -526,6 +544,8 @@ paths:
             text/plain:
               schema:
                 $ref: "#/components/schemas/ServiceInfo"
+      security:
+        - BEARER: []
   /toolClasses:
     get:
       summary: List all tool types
@@ -548,6 +568,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/ToolClass"
+      security:
+        - BEARER: []
 externalDocs:
   description: Description of GA4GH Tool Registry (Exchange) Schema
   url: https://github.com/ga4gh/tool-registry-schemas
@@ -573,6 +595,11 @@ components:
         results.
       schema:
         type: string
+  securitySchemes:
+    BEARER:
+      type: apiKey
+      name: Authorization
+      in: header
   schemas:
     ToolFile:
       type: object


### PR DESCRIPTION
Address security questionnaire feedback
Add an undefined option for oauth (for private registries?)

On approval will also add text to webpage along the lines of:

-----------

GA4GH recommends the use of the OAuth 2.0 framework (RFC 6749) for authentication and authorization. It is also recommended that implementations of this standard implement and follow the GA4GH Authentication and Authorization Infrastructure (AAI) standard.

While the TRS standard itself does not define any behaviour specific to authorization, given that it hosts and shares publicly available workflows. For future expansion, we recommend that if authorization is needed, that it follows the OAuth 2.0 recommendations as defined above. 

