### PR TITLE
Corrects link to GA4GH . checksum hash algorithm registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Schemas for the GA4GH Tool Registry API
 
 This repository is the home for the schema for the GA4GH Tool Registry API.  The goal of the API is to provide a standardized way to describe the availability of tools and workflows.  In this way, we can have multiple repositories that share Docker-based tools and WDL/CWL/Nextflow-based workflows and have a consistent way to interact, search, and retrieve information from these various registries.  The end goal is to make it much easier to share scientific tools and workflows, enhancing our ability to make research reproducible, sharable, and transparent.
 
-**See the human-readable [Reference Documentation](https://ga4gh.github.io/tool-registry-service-schemas/Introduction/). You can also explore the specification in the [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/openapi/ga4gh-tool-discovery.yaml).**  *Manually load the JSON if working from a non-develop branch version.*
+**See the human-readable [Reference Documentation](https://ga4gh.github.io/tool-registry-service-schemas/). You can also explore the specification in the [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/openapi/ga4gh-tool-discovery.yaml).**  *Manually load the JSON if working from a non-develop branch version.*
 
 See our generated doc
 

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -473,7 +473,7 @@ definitions:
         type: string
         description: |-
           The digest method used to create the checksum.
-          The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-hash-alg-registry/blob/master/hash-alg.csv[GA4GH Hash Algorithm Registry].
+          The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv[GA4GH Checksum Hash Algorithm Registry].
           Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920].
           GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future.
   ToolFile:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -598,7 +598,7 @@ components:
           description: >-
             The digest method used to create the checksum.
 
-            The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-hash-alg-registry/blob/master/hash-alg.csv[GA4GH Hash Algorithm Registry].
+            The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv[GA4GH Checksum Hash Algorithm Registry].
 
             Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920].
 


### PR DESCRIPTION
- [x] Corrected hash-alg registry link in openapi/ga4gh-tool-discovery.yaml
- [x] Corrected hash-alg registry link in openapi/openapi.yaml