### PR TITLE
Glitchy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![ga4gh logo](https://github.com/dockstore/dockstore-ui2/raw/develop/src/assets/images/sponsors/coloured/ga4gh.png)
 
-[![DOI](https://zenodo.org/badge/48013867.svg)](https://zenodo.org/badge/latestdoi/48013867)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3374001.svg)](https://doi.org/10.5281/zenodo.3374001)
 
 
 Schemas for the GA4GH Tool Registry API
@@ -9,8 +9,6 @@ Schemas for the GA4GH Tool Registry API
 This repository is the home for the schema for the GA4GH Tool Registry API.  The goal of the API is to provide a standardized way to describe the availability of tools and workflows.  In this way, we can have multiple repositories that share Docker-based tools and WDL/CWL/Nextflow-based workflows and have a consistent way to interact, search, and retrieve information from these various registries.  The end goal is to make it much easier to share scientific tools and workflows, enhancing our ability to make research reproducible, sharable, and transparent.
 
 **See the human-readable [Reference Documentation](https://ga4gh.github.io/tool-registry-service-schemas). You can also explore the specification in the [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/openapi/ga4gh-tool-discovery.yaml).**  *Manually load the JSON if working from a non-develop branch version.*
-
-See our generated doc
 
 The [Global Alliance for Genomics and Health](http://genomicsandhealth.org/) (GA4GH) is an international
 coalition, formed to enable the sharing of genomic and clinical data.


### PR DESCRIPTION
A floating badge seems to kill the link checker 
(zenodo probably takes time to prep the link)