### PR TITLE
download all files as zip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk: openjdk8
 
 # looks like papa32 plugin 1.5.0 is no longer compatible with gradle 5, the other option is to try running without it
 before_install:
-  - wget http://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+  - wget https://services.gradle.org/distributions/gradle-4.10.2-bin.zip
   - unzip -qq gradle-4.10.2-bin.zip
   - export GRADLE_HOME=$PWD/gradle-4.10.2
   - export PATH=$GRADLE_HOME/bin:$PATH

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -367,6 +367,9 @@ paths:
         /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}
         endpoint.
       operationId: toolsIdVersionsVersionIdTypeFilesGet
+      produces:
+        - application/json
+        - application/zip
       tags:
         - GA4GH
       parameters:
@@ -391,6 +394,12 @@ paths:
           description: >-
             An identifier of the tool version for this particular tool registry,
             for example `v1`.
+        - name: format
+          in: query
+          required: false
+          type: string
+          enum:
+            - zip
       responses:
         '200':
           description: The array of File JSON responses.

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -365,7 +365,7 @@ paths:
         Get a list of objects that contain the relative path and file type. The
         descriptors are intended for use with the
         /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}
-        endpoint. Specify format=zip to get a zip file of all files available instead.
+        endpoint. Specify format=zip to download a zip file of all files instead.
       operationId: toolsIdVersionsVersionIdTypeFilesGet
       produces:
         - application/json
@@ -398,7 +398,7 @@ paths:
           in: query
           required: false
           type: string
-          description: specify format=zip to download a zip file of all files available
+          description: Specify format=zip to download a zip file of all files instead.
           enum:
             - zip
       responses:

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -365,7 +365,7 @@ paths:
         Get a list of objects that contain the relative path and file type. The
         descriptors are intended for use with the
         /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}
-        endpoint. If format=zip is specified, a zip file of all files available will be gotten instead.
+        endpoint. Specify format=zip to get a zip file of all files available instead.
       operationId: toolsIdVersionsVersionIdTypeFilesGet
       produces:
         - application/json

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -365,7 +365,7 @@ paths:
         Get a list of objects that contain the relative path and file type. The
         descriptors are intended for use with the
         /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}
-        endpoint. Specify format=zip to download a zip file of all files instead.
+        endpoint. Returns a zip file of all files when format=zip is specified.
       operationId: toolsIdVersionsVersionIdTypeFilesGet
       produces:
         - application/json
@@ -398,7 +398,7 @@ paths:
           in: query
           required: false
           type: string
-          description: Specify format=zip to download a zip file of all files instead.
+          description: Returns a zip file of all files when format=zip is specified.
           enum:
             - zip
       responses:

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -365,7 +365,7 @@ paths:
         Get a list of objects that contain the relative path and file type. The
         descriptors are intended for use with the
         /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}
-        endpoint.
+        endpoint. If format=zip is specified, a zip file of all files available will be gotten instead.
       operationId: toolsIdVersionsVersionIdTypeFilesGet
       produces:
         - application/json
@@ -398,6 +398,7 @@ paths:
           in: query
           required: false
           type: string
+          description: specify format=zip to download a zip file of all files available
           enum:
             - zip
       responses:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -428,7 +428,7 @@ paths:
       description: Get a list of objects that contain the relative path and file type. The
         descriptors are intended for use with the
         /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}
-        endpoint. Specify format=zip to get a zip file of all files available
+        endpoint. Specify format=zip to download a zip file of all files
         instead.
       operationId: toolsIdVersionsVersionIdTypeFilesGet
       tags:
@@ -458,7 +458,7 @@ paths:
         - name: format
           in: query
           required: false
-          description: specify format=zip to download a zip file of all files available
+          description: Specify format=zip to download a zip file of all files instead.
           schema:
             type: string
             enum:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -428,8 +428,7 @@ paths:
       description: Get a list of objects that contain the relative path and file type. The
         descriptors are intended for use with the
         /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}
-        endpoint. Specify format=zip to download a zip file of all files
-        instead.
+        endpoint. Returns a zip file of all files when format=zip is specified.
       operationId: toolsIdVersionsVersionIdTypeFilesGet
       tags:
         - GA4GH
@@ -458,7 +457,7 @@ paths:
         - name: format
           in: query
           required: false
-          description: Specify format=zip to download a zip file of all files instead.
+          description: Returns a zip file of all files when format=zip is specified.
           schema:
             type: string
             enum:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -428,8 +428,8 @@ paths:
       description: Get a list of objects that contain the relative path and file type. The
         descriptors are intended for use with the
         /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}
-        endpoint. If format=zip is specified, a zip file of all files available
-        will be gotten instead.
+        endpoint. Specify format=zip to get a zip file of all files available
+        instead.
       operationId: toolsIdVersionsVersionIdTypeFilesGet
       tags:
         - GA4GH


### PR DESCRIPTION
For #116 

Add query parameter to get zip file of everything

Also fix for missing gradle

See https://ga4gh.github.io/tool-registry-service-schemas/swagger-ui/?url=../preview/feature/116/bundles/docs/web_deploy/swagger.json#/GA4GH/toolsIdVersionsVersionIdTypeFilesGet for how the swagger-ui looks like 

The issue mentions to add the query parameter to an existing endpoint. There are some issues representing that in swagger right now because the same response code generates two different schemas