### PR TITLE
Snakemake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Schemas for the GA4GH Tool Registry API
 =======================================
 
-This repository is the home for the schema for the GA4GH Tool Registry API.  The goal of the API is to provide a standardized way to describe the availability of tools and workflows.  In this way, we can have multiple repositories that share Docker-based tools and WDL/CWL/Nextflow/Galaxy-based workflows and have a consistent way to interact, search, and retrieve information from these various registries.  The end goal is to make it much easier to share scientific tools and workflows, enhancing our ability to make research reproducible, sharable, and transparent.
+This repository is the home for the schema for the GA4GH Tool Registry API.  The goal of the API is to provide a standardized way to describe the availability of tools and workflows.  In this way, we can have multiple repositories that share Docker-based tools and WDL/CWL/Nextflow/Galaxy/Snakemake-based workflows and have a consistent way to interact, search, and retrieve information from these various registries.  The end goal is to make it much easier to share scientific tools and workflows, enhancing our ability to make research reproducible, sharable, and transparent.
 
 **See the human-readable [Reference Documentation](https://ga4gh.github.io/tool-registry-service-schemas). You can also explore the specification in the [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/openapi/ga4gh-tool-discovery.yaml).**  *Manually load the JSON if working from a non-develop branch version.* Preview documentation from the [gh-openapi-docs](https://github.com/ga4gh/gh-openapi-docs) for the development branch [here](https://ga4gh.github.io/tool-registry-service-schemas/preview/develop/docs/index.html)
 
@@ -26,7 +26,7 @@ The Containers & Workflows working group is an informal, multi-vendor working gr
 What is the Tool Registry API Schema?
 -------------------------------------
 
-This is the home of the schema for the GA4GH Tool Registry API. The GA4GH Tool Registry API is a standard for listing and describing available tools (both stand-alone, Docker-based tools as well as workflows in CWL, WDL, Nextflow, or Galaxy) in a given registry. This defines a minimal, common API describing tools that we propose for support by multiple tool/workflow registries like [Dockstore](https://www.dockstore.org/), [BioContainers](https://biocontainers.pro), and [Agora](https://github.com/broadinstitute/agora) for the purposes of exchange, indexing, and searching.
+This is the home of the schema for the GA4GH Tool Registry API. The GA4GH Tool Registry API is a standard for listing and describing available tools (both stand-alone, Docker-based tools as well as workflows in CWL, WDL, Nextflow, Galaxy or Snakemake) in a given registry. This defines a minimal, common API describing tools that we propose for support by multiple tool/workflow registries like [Dockstore](https://www.dockstore.org/), [BioContainers](https://biocontainers.pro), and [Agora](https://github.com/broadinstitute/agora) for the purposes of exchange, indexing, and searching.
 
 This repo uses the [HubFlow](https://datasift.github.io/gitflow/) scheme which is closely based on [GitFlow](https://nvie.com/posts/a-successful-git-branching-model/). In practice, this means that the master branch contains the last production release of the schema whereas the develop branch contains the latest development changes which will end up in the next production release. 
 As of July 2019, this means that the 1.0.0 version is described on master whereas the develop branch contains the 2.0.0-beta.3 version which will evolve into the 2.0.0 production release.
@@ -36,7 +36,8 @@ Our current proposal is to start with a read-only API due to potentially differe
 Key features of the current API proposal:
 
 * read-only API
-* May serve up CWL, WDL or Nextflow to describe a tool or represent a workflow depending on the tool/workflow submitter
+* May serve up CWL, WDL, Nextflow, Galaxy or Snakemake to describe a tool or represent a workflow 
+  depending on the tool/workflow submitter
 * ID:  globally unique across systems and also identifies the system that it came from (ex: 123456323@agora.broadinstitute.org )
 
 

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -5,15 +5,15 @@ info:
     Proposed API for GA4GH (Global Alliance for Genomics & Health) tool
     repositories. A tool consists of a set of container images that are paired
     with a set of documents. Examples of documents include CWL (Common Workflow
-    Language), WDL (Workflow Description Language), NFL (Nextflow), or GXFORMAT2 (Galaxy) that
-    describe how to use those images and a set of specifications for those
-    images (examples are Dockerfiles or Singularity recipes) that describe how
-    to reproduce those images in the future. We use the following terminology, a
-    "container image" describes a container as stored at rest on a filesystem, a
-    "tool" describes one of the triples as described above. In practice,
-    examples of "tools" include CWL CommandLineTools, CWL Workflows, WDL
-    workflows, and Nextflow workflows that reference containers in formats such
-    as Docker or Singularity.
+    Language), WDL (Workflow Description Language), NFL (Nextflow), GXFORMAT2
+    (Galaxy), or SMK (Snakemake) that describe how to use those images and a set
+    of specifications for those images (examples are Dockerfiles or Singularity
+    recipes) that describe how to reproduce those images in the future. We use
+    the following terminology, a "container image" describes a container as
+    stored at rest on a filesystem, a "tool" describes one of the triples as
+    described above. In practice, examples of "tools" include CWL
+    CommandLineTools, CWL Workflows, WDL workflows, and Nextflow workflows that
+    reference containers in formats such as Docker or Singularity.
   version: 2.0.1
 produces:
   - application/json
@@ -219,7 +219,7 @@ paths:
       operationId: toolsIdVersionsVersionIdTypeDescriptorGet
       description: >-
         Returns the descriptor for the specified tool (examples include CWL,
-        WDL, Nextflow, or Galaxy documents).
+        WDL, Nextflow, Galaxy, or Snakemake documents).
       tags:
         - GA4GH
       parameters:
@@ -230,7 +230,8 @@ paths:
             The output type of the descriptor. Plain types return the bare
             descriptor while the "non-plain" types return a descriptor wrapped
             with metadata. Allowable values include "CWL", "WDL", "NFL", "GALAXY",
-            "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL", "PLAIN_GALAXY".
+            "SMK", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL", "PLAIN_GALAXY",
+            "PLAIN_SMK".
           type: string
         - name: id
           in: path
@@ -280,7 +281,8 @@ paths:
             underlying implementation to determine which output type to return.
             Plain types return the bare descriptor while the "non-plain" types
             return a descriptor wrapped with metadata. Allowable values are
-            "CWL", "WDL", "NFL", "GALAXY", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL", "PLAIN_GALAXY".
+            "CWL", "WDL", "NFL", "GALAXY", "SMK", "PLAIN_CWL", "PLAIN_WDL",
+            "PLAIN_NFL", "PLAIN_GALAXY", "PLAIN_SMK".
           type: string
         - name: id
           in: path
@@ -333,10 +335,10 @@ paths:
           in: path
           description: >-
             The type of the underlying descriptor. Allowable values include
-            "CWL", "WDL", "NFL", "GALAXY", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL", "PLAIN_GALAXY". For
-            example, "CWL" would return an list of ToolTests objects while
-            "PLAIN_CWL" would return a bare JSON list with the content of the
-            tests.
+            "CWL", "WDL", "NFL", "GALAXY", "SMK", "PLAIN_CWL", "PLAIN_WDL",
+            "PLAIN_NFL", "PLAIN_GALAXY", "PLAIN_SMK". For example, "CWL" would
+            return a list of ToolTests objects while "PLAIN_CWL" would return
+            a bare JSON list with the content of the tests.
           type: string
         - name: id
           in: path
@@ -385,7 +387,7 @@ paths:
           in: path
           description: >-
             The output type of the descriptor. Examples of allowable values are
-            "CWL", "WDL", "NFL", "GALAXY".
+            "CWL", "WDL", "NFL", "GALAXY", "SMK".
           type: string
         - name: id
           in: path
@@ -717,14 +719,15 @@ definitions:
     type: string
     description: >-
       The type of descriptor that represents this version of the tool (e.g. CWL,
-      WDL, NFL, or GALAXY). Note that these files can also include associated
-      Docker/container files  and test parameters that further describe a
-      version of a tool.
+      WDL, NFL, GALAXY, or Snakemake). Note that these files can also include
+      associated Docker/container files  and test parameters that further
+      describe a version of a tool.
     enum:
       - CWL
       - WDL
       - NFL
       - GALAXY
+      - SMK
   FileWrapper:
     type: object
     description: >

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -4,15 +4,15 @@ info:
   description: Proposed API for GA4GH (Global Alliance for Genomics & Health) tool
     repositories. A tool consists of a set of container images that are paired
     with a set of documents. Examples of documents include CWL (Common Workflow
-    Language), WDL (Workflow Description Language), NFL (Nextflow), or GXFORMAT2
-    (Galaxy) that describe how to use those images and a set of specifications
-    for those images (examples are Dockerfiles or Singularity recipes) that
-    describe how to reproduce those images in the future. We use the following
-    terminology, a "container image" describes a container as stored at rest on
-    a filesystem, a "tool" describes one of the triples as described above. In
-    practice, examples of "tools" include CWL CommandLineTools, CWL Workflows,
-    WDL workflows, and Nextflow workflows that reference containers in formats
-    such as Docker or Singularity.
+    Language), WDL (Workflow Description Language), NFL (Nextflow), GXFORMAT2
+    (Galaxy) or SMK (Snakemake) that describe how to use those images and a set
+    of specifications for those images (examples are Dockerfiles or Singularity
+    recipes) that describe how to reproduce those images in the future. We use
+    the following terminology, a "container image" describes a container as
+    stored at rest on a filesystem, a "tool" describes one of the triples as
+    described above. In practice, examples of "tools" include CWL
+    CommandLineTools, CWL Workflows, WDL workflows, and Nextflow workflows that
+    reference containers in formats such as Docker or Singularity.
   version: 2.0.1
 tags:
   - name: GA4GH
@@ -254,7 +254,7 @@ paths:
       summary: Get the tool descriptor for the specified tool
       operationId: toolsIdVersionsVersionIdTypeDescriptorGet
       description: Returns the descriptor for the specified tool (examples include
-        CWL, WDL, Nextflow, or Galaxy documents).
+        CWL, WDL, Nextflow, Galaxy, or Snakemake documents).
       tags:
         - GA4GH
       parameters:
@@ -264,7 +264,8 @@ paths:
           description: The output type of the descriptor. Plain types return the bare
             descriptor while the "non-plain" types return a descriptor wrapped
             with metadata. Allowable values include "CWL", "WDL", "NFL",
-            "GALAXY", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL", "PLAIN_GALAXY".
+            "GALAXY", "SMK", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL",
+            "PLAIN_GALAXY", "PLAIN_SMK".
           schema:
             type: string
         - name: id
@@ -323,8 +324,8 @@ paths:
             the underlying implementation to determine which output type to
             return. Plain types return the bare descriptor while the "non-plain"
             types return a descriptor wrapped with metadata. Allowable values
-            are "CWL", "WDL", "NFL", "GALAXY", "PLAIN_CWL", "PLAIN_WDL",
-            "PLAIN_NFL", "PLAIN_GALAXY".
+            are "CWL", "WDL", "NFL", "GALAXY", "SMK", "PLAIN_CWL", "PLAIN_WDL",
+            "PLAIN_NFL", "PLAIN_GALAXY", "PLAIN_SMK".
           schema:
             type: string
         - name: id
@@ -386,10 +387,10 @@ paths:
           required: true
           in: path
           description: The type of the underlying descriptor. Allowable values include
-            "CWL", "WDL", "NFL", "GALAXY", "PLAIN_CWL", "PLAIN_WDL",
-            "PLAIN_NFL", "PLAIN_GALAXY". For example, "CWL" would return an list
-            of ToolTests objects while "PLAIN_CWL" would return a bare JSON list
-            with the content of the tests.
+            "CWL", "WDL", "NFL", "GALAXY", "SMK", "PLAIN_CWL", "PLAIN_WDL",
+            "PLAIN_NFL", "PLAIN_GALAXY", "PLAIN_SMK". For example, "CWL" would
+            return a list of ToolTests objects while "PLAIN_CWL" would return
+            a bare JSON list with the content of the tests.
           schema:
             type: string
         - name: id
@@ -446,7 +447,7 @@ paths:
           required: true
           in: path
           description: The output type of the descriptor. Examples of allowable values are
-            "CWL", "WDL", "NFL", "GALAXY".
+            "CWL", "WDL", "NFL", "GALAXY", "SMK".
           schema:
             type: string
         - name: id
@@ -836,7 +837,7 @@ components:
     DescriptorType:
       type: string
       description: The type of descriptor that represents this version of the tool
-        (e.g. CWL, WDL, NFL, or GALAXY). Note that these files can also include
+        (e.g. CWL, WDL, NFL, GALAXY, SMK). Note that these files can also include
         associated Docker/container files  and test parameters that further
         describe a version of a tool.
       enum:
@@ -844,6 +845,7 @@ components:
         - WDL
         - NFL
         - GALAXY
+        - SMK
     FileWrapper:
       type: object
       description: >


### PR DESCRIPTION
* Include `SMK` (Snakemake) in `DescriptorType` enum
* Add `SMK`, `PLAIN_SMK`, and Snakemake to OpenAPI descriptions and `README.md`, where applicable

resolves #156