### PR TITLE
Fix table of contents generation

### DIFF
--- a/TableOfContents.md
+++ b/TableOfContents.md
@@ -98,8 +98,10 @@ dependabot/npm_and_yarn/y18n-4.0.3:
 [ReDoc](preview/dependabot/npm_and_yarn/y18n-4.0.3/docs/index.html)
 
 feature/auditFix: 
+[ReDoc](preview/feature/auditfix/docs/index.html)
 
 feature/testUppercase: 
+[ReDoc](preview/feature/testuppercase/docs/index.html)
 
 master: 
 [swagger-ui](swagger-ui?url=../preview/master/docs/web_deploy/swagger.json)

--- a/scripts/create-table-of-contents.sh
+++ b/scripts/create-table-of-contents.sh
@@ -67,7 +67,8 @@ do
 		{ 
 		  echo ""
 		  echo "$branch: "
-		  createLinks $branch
+		  LBN=$(echo $branch | tr '[:upper:]' '[:lower:]')
+		  createLinks $LBN
 	        } >> $FILENAME
 	fi
 done


### PR DESCRIPTION
Turns out the doc generation is creating the directory using the lower case branch name (not sure since when, might've always been like that)