### PR TITLE
Describe versioned TRS URIs

### DIFF
--- a/2.0.0-Data-Model.md
+++ b/2.0.0-Data-Model.md
@@ -12,21 +12,78 @@ We are starting with a read-only API due to potentially different views and appr
 
 Multiple formats for descriptors such as [CWL](https://github.com/common-workflow-language/common-workflow-language) and [WDL](https://github.com/broadinstitute/wdl) are permitted. 
 
+#### TRS Tool and TRS Tool Version IDs
+
+Each implementation of TRS can choose its own identifier scheme, as long as it
+follows these guidelines:
+
+* TRS Tool and TRS Tool Version IDs are strings made up of uppercase and
+  lowercase letters, decimal digits, hyphen, period, underscore and tilde
+  (`[A-Za-z0-9.-_~]`). See [RFC 3986 §
+  2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3). TRS Tool and
+  TRS Tool Version IDs MAY further contain percent characters (`%`) whenever
+  they are used in API calls, but only if they were introduced through
+  percent-encoding of any non-valid characters (see next bullet point).
+* TRS Tool and TRS Tool Version IDs can contain other characters, but they MUST
+  be percent-encoded (see [RFC 3986 §
+  2.4](https://datatracker.ietf.org/doc/html/rfc3986#section-2.4)) into valid
+  TRS Tool and TRS Tool Version IDs as per the previous rule whenever they are
+  used in API calls. This is because non-encoded IDs may interfere with the
+  interpretation of routes, e.g., for the `/tools/{id}/versions/{version_id}`
+  endpoint.
+* Any given TRS Tool or TRS Tool Version ID MUST always identify the same
+  resource (tool or tool version, respectively) on a given TRS implementation.
+  This constraint aids with reproducibility.
+* TRS implementations MAY have more than one TRS Tool or TRS Tool Versoin ID
+  mapping to the same resource (tool or tool version, respectively).
+
 #### TRS URIs
 
-For convenience, including potentially when passing content references to a WES server, we define a URI syntax for TRS-accessible content. Strings of the form `trs://<server>/<id>` mean _“you can fetch the content with TRS id `<id>` from the TRS server at `<server>` "_.
+To convienently pass content references to TRS resources, e.g., to advise a
+[WES](https://github.com/ga4gh/workflow-execution-service-schemas) or
+[TES](https://github.com/ga4gh/task-execution-schemas) service which tool
+(version) to use, we define a URI syntax for TRS-accessible content. Strings of
+the form `trs://<server>/<id>` (unversioned) and
+`trs://<server>/<id>/<version_id>` (versioned) mean _“you can fetch the content
+with TRS Tool ID `<id>` and, if provided, TRS Tool Version ID `<version_id>`
+from the TRS server at `<server>` "_.
 
-For example, if a WES server was asked to process `trs://trs.example.org/123456323`, it would know that it could issue a GET request to `https://trs.example.org/api/ga4gh/trs/v2/tools/123456323` to learn how to fetch that object.
+For example, if a TRS client was asked to process
+`trs://trs.example.org/tool_ABC/v1.2.3`, it would know that it could, e.g.,
+issue `GET` requests to
+`https://trs.example.org/api/ga4gh/trs/v2/tools/tool_ABC` and
+`https://trs.example.org/api/ga4gh/trs/v2/tools/tool_ABC/versions/v1.2.3` to
+fetch information about tool `tool_ABC` and its version `v1.2.3`,
+respectively.
 
-This recommendation is intended to mirror the discussion that went into the [DRS URI scheme](https://ga4gh.github.io/data-repository-service-schemas/preview/develop/docs/#_drs_uris).
+> Note that clients issuing requests to TRS services MUST NOT encode forward
+> the special characters slashes separating the `trs`, `<server>`, `<id>` and
+> `<version_id>` components of TRS URIs. However, [TRS Tool IDs and TRS Tool
+> Version IDs](#trs-tool-and-trs-tool-version-ids) containing
+> non-valid characters MUST be encoded _individually_ before constructing TRS
+> URIs. For example, for a TRS Tool ID `tool#1` and a TRS Version ID `(1)`, the
+> correct TRS URI for server `trs.example.org` would be
+> `trs://trs.example.org/tool%231/%281%29`, where `tool%231` and `%281%29` are
+> the percent-encoded TRS Tool and TRS Tool Version IDs, respectively.
 
-For informational purposes, we recommend that TRS implementations add themselves to https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json to provide for the possibility of creating a global indexing service and to allow others to more easily discover a TRS implementation. 
+This recommendation is intended to mirror the discussion that went into the
+[DRS URI
+scheme](https://ga4gh.github.io/data-repository-service-schemas/preview/develop/docs/#_drs_uris),
+with the necessary additions to account for versioned TRS URIs.
 
 ### Misc
 
 The entire schema is shown below, but a more useful form is the Swagger editor to view our [schema in progress](https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh/tool-registry-service-schemas/develop/openapi/ga4gh-tool-discovery.yaml) 
 
 Note that the swagger editor itself can kickstart a project by generating servers and clients in a variety of languages.
+
+#### Central GA4GH Service Registry
+
+For informational purposes, we recommend that TRS implementations add
+themselves to
+<https://github.com/ga4gh/tool-registry-service-schemas/blob/develop/registry.json>
+to provide for the possibility of creating a global indexing service and to
+allow others to more easily discover a TRS implementation.
 
 #### Outstanding Questions
 

--- a/2.0.0-Data-Model.md
+++ b/2.0.0-Data-Model.md
@@ -53,8 +53,8 @@ For example, if a TRS client was asked to process
 issue `GET` requests to
 `https://trs.example.org/api/ga4gh/trs/v2/tools/tool_ABC` and
 `https://trs.example.org/api/ga4gh/trs/v2/tools/tool_ABC/versions/v1.2.3` to
-fetch information about tool `tool_ABC` and its version `v1.2.3`,
-respectively.
+fetch information about tool `tool_ABC` and its version `v1.2.3` from a `v2`
+TRS API hosted at `https://trs.example.org/`, respectively.
 
 > Note that clients issuing requests to TRS services MUST NOT encode forward
 > the special characters slashes separating the `trs`, `<server>`, `<id>` and
@@ -65,6 +65,11 @@ respectively.
 > correct TRS URI for server `trs.example.org` would be
 > `trs://trs.example.org/tool%231/%281%29`, where `tool%231` and `%281%29` are
 > the percent-encoded TRS Tool and TRS Tool Version IDs, respectively.
+>  
+> Also note that to ensure reproducibility, servers implementing multiple
+> versions of the TRS API specification MUST ensure that, within the limits of
+> schema differences across different API versions, corresponding endpoints
+> return consistent responses.
 
 This recommendation is intended to mirror the discussion that went into the
 [DRS URI

--- a/2.0.0-Data-Model.md
+++ b/2.0.0-Data-Model.md
@@ -34,12 +34,12 @@ follows these guidelines:
 * Any given TRS Tool or TRS Tool Version ID MUST always identify the same
   resource (tool or tool version, respectively) on a given TRS implementation.
   This constraint aids with reproducibility.
-* TRS implementations MAY have more than one TRS Tool or TRS Tool Versoin ID
+* TRS implementations MAY have more than one TRS Tool or TRS Tool Version ID
   mapping to the same resource (tool or tool version, respectively).
 
 #### TRS URIs
 
-To convienently pass content references to TRS resources, e.g., to advise a
+To conveniently pass content references to TRS resources, e.g., to advise a
 [WES](https://github.com/ga4gh/workflow-execution-service-schemas) or
 [TES](https://github.com/ga4gh/task-execution-schemas) service which tool
 (version) to use, we define a URI syntax for TRS-accessible content. Strings of


### PR DESCRIPTION
#### Rationale

TRS URIs allow passing references to TRS content to potential TRS client applications (e.g., [WES](https://github.com/ga4gh/workflow-execution-service-schemas) or [TES](https://github.com/ga4gh/task-execution-schemas)). This PR adds support for _versioned_ TRS URIs, which are required to specify which version of a specified tool the client application is supposed to use/consume. This is essential to ensure reproducibility for at least some of the main use cases of TRS URIs (e.g., fetching workflows or containers).

#### Implementation details

- Extend definition of TRS URIs (`trs://<server>/<id>`) in TRS Data Model documentation to include _versioned_ TRS URI (`trs://<server>/<id>/<version_id>`)
- Add guidelines on defining TRS Tool and TRS Tool Version IDs, based on corresponding description in [DRS Data Model documentation](https://ga4gh.github.io/data-repository-service-schemas/preview/develop/docs/#section/DRS-IDs)
- Include detailed information on how to encode TRS Tool (Version) IDs containing characters that are invalid during API calls and an example how to construct a valid, verisioned TRS URI from them
- Moved recommendation to publish deployed TRS services in the centralized GA4GH Service Registry to its own subsection under section `Misc`

#### Related issues

Resolves #164 (see issue for additional details and a community discussion of the implementation proposed here)