### PR TITLE
fix: add missing SMK to enum of supported types

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -722,6 +722,7 @@ components:
         - WDL
         - NFL
         - GALAXY
+        - SMK
         - PLAIN_CWL
         - PLAIN_WDL
         - PLAIN_NFL


### PR DESCRIPTION
Add `SMK` to enum in `DescriptorTypeWithPlain` model.