### PR TITLE
Added descriptor_type_version to ToolVersion definition

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -636,12 +636,14 @@ components:
             `descriptor_type`
           example: |
             {
-              "WDL": "1.0",
-              "CWL": "v1.0.2",
-              "NFL": "22.04.0"
+              "WDL": ["1.0"],
+              "CWL": ["v1.0.2"],
+              "NFL": ["DSL2"]
             }
           additionalProperties:
-            $ref: "#/components/schemas/DescriptorTypeVersion"
+            type: array
+            items:
+              $ref: "#/components/schemas/DescriptorTypeVersion"
         containerfile:
           type: boolean
           description: Reports if this tool has a containerfile available. (For

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -629,6 +629,19 @@ components:
           description: The type (or types) of descriptors available.
           items:
             $ref: "#/components/schemas/DescriptorType"
+        descriptor_type_version:
+          type: object
+          description: A map providing information about the language versions used in this tool. The keys should be the
+            same values in the `descriptor_type` table, and the value should be the actual language version for the given
+            `descriptor_type`
+          example: |
+            {
+              "WDL": "1.0",
+              "CWL": "v1.0.2",
+              "NFL": "22.04.0"
+            }
+          additionalProperties:
+            $ref: "#/components/schemas/DescriptorTypeVersion"
         containerfile:
           type: boolean
           description: Reports if this tool has a containerfile available. (For
@@ -713,6 +726,11 @@ components:
         - WDL
         - NFL
         - GALAXY
+    DescriptorTypeVersion:
+      type: string
+      description: The language version this tool is written in for a given descriptor type. The versions should correspond
+        to the actual declared version of the descriptor. For example, tools defined in CWL may have a version of `v1.0.2`
+        whereas WDL tools may have a version of `1.0` or `draft-2`
     DescriptorTypeWithPlain:
       type: string
       description: The output type of the descriptor. Plain types return the raw text while the "non-plain" types return the application/json

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -632,8 +632,9 @@ components:
         descriptor_type_version:
           type: object
           description: A map providing information about the language versions used in this tool. The keys should be the
-            same values in the `descriptor_type` table, and the value should be an array of the the actual language version for the given
-            `descriptor_type`
+            same values used in the `descriptor_type` field, and the value should be an array of all the language versions used 
+            for the given `descriptor_type`. Depending on the `descriptor_type` (ex CWL) multiple version values may be used
+            in a single tool.
           example: |
             {
               "WDL": ["1.0"],
@@ -730,7 +731,7 @@ components:
         - GALAXY
     DescriptorTypeVersion:
       type: string
-      description: The language version this tool is written in for a given descriptor type. The versions should correspond
+      description: The language version for a given descriptor type. The version should correspond
         to the actual declared version of the descriptor. For example, tools defined in CWL may have a version of `v1.0.2`
         whereas WDL tools may have a version of `1.0` or `draft-2`
     DescriptorTypeWithPlain:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -633,11 +633,11 @@ components:
           type: object
           description: A map providing information about the language versions used in this tool. The keys should be the
             same values used in the `descriptor_type` field, and the value should be an array of all the language versions used 
-            for the given `descriptor_type`. Depending on the `descriptor_type` (ex CWL) multiple version values may be used
+            for the given `descriptor_type`. Depending on the `descriptor_type` (e.g. CWL) multiple version values may be used
             in a single tool.
           example: |
             {
-              "WDL": ["1.0"],
+              "WDL": ["1.0", "1.0"],
               "CWL": ["v1.0.2"],
               "NFL": ["DSL2"]
             }
@@ -733,7 +733,7 @@ components:
     DescriptorTypeVersion:
       type: string
       description: The language version for a given descriptor type. The version should correspond
-        to the actual declared version of the descriptor. For example, tools defined in CWL may have a version of `v1.0.2`
+        to the actual declared version of the descriptor. For example, tools defined in CWL could have a version of `v1.0.2`
         whereas WDL tools may have a version of `1.0` or `draft-2`
     DescriptorTypeWithPlain:
       type: string

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -632,7 +632,7 @@ components:
         descriptor_type_version:
           type: object
           description: A map providing information about the language versions used in this tool. The keys should be the
-            same values in the `descriptor_type` table, and the value should be the actual language version for the given
+            same values in the `descriptor_type` table, and the value should be an array of the the actual language version for the given
             `descriptor_type`
           example: |
             {


### PR DESCRIPTION
## What
I would like to propose adding a new field: `descriptor_type_version` to the `ToolVersion` object in order communicate the specific language level a particular `descriptor_type` is written in. The field is a simple `map` in the tool version, where the keys correspond to on of the `descriptor_type`'s and the values are the actual underlying  version.

Adding a new property does add a level of redundancy (ie reporting the `descriptor_type` twice). However, it does maintain backwards compatibility with the current spec version

```json
{
  "descriptor_type": [
    "CWL",
    "WDL"
  ],
  "descriptor_type_version": {
    "CWL": "v1.0.2",
    "WDL": "1.0"
   }
}
``` 

## Rationale
In `WES` there is a required field when submitting a new run: `workflow_type_version`. Workflow execution engines may handle run submissions differently depending on the reported language level. For example, an engine may only support version `1.0` of WDL or `v1.0.2` of CWL. It may also use different workers depending on the language version specified by the user. 

It would be my hope that we could relax the requirement in `WES` to require the `worflow_type` and `workflow_type_version` when a `TRS` uri is used. Unfortuantely, since `TRS` does not report the underlying version, we do not have the needed features to programatically look up this information without parsing the descriptor. Parsing the descriptor to get the version is not always possible as some languages do not report the version directly in their descriptor  

Additionally, when building applications that interact with tools/tool versions, it would be helpful to have this information available to build version specific elements in UI's or other tooling