### PR TITLE
docs: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ What is the Tool Registry API Schema?
 
 This is the home of the schema for the GA4GH Tool Registry API. The GA4GH Tool Registry API is a standard for listing and describing available tools (both stand-alone, self-contained tools and workflows in CWL, WDL, Nextflow, Galaxy or Snakemake) in a given registry. This defines a minimal, common API describing tools that we propose for support by multiple tool/workflow registries like [Dockstore](https://www.dockstore.org/), [BioContainers](https://biocontainers.pro), and [Agora](https://github.com/broadinstitute/agora) for the purposes of exchange, indexing, and searching.
 
-This repo uses the [HubFlow](https://datasift.github.io/gitflow/) scheme which is closely based on [GitFlow](https://nvie.com/posts/a-successful-git-branching-model/). In practice, this means that the master branch contains the last production release of the schema whereas the develop branch contains the latest development changes which will end up in the next production release. 
-As of February 2022,  the master branch contains the last production release (currently ![release_badge](https://img.shields.io/github/v/tag/ga4gh/tool-registry-service-schemas))) whereas the develop branch contains work which will accumulate and evolve into a 2.1 production release.
+This repo uses the [HubFlow](https://github.com/mvalipour/hubflow) scheme which is closely based on 
+[GitFlow](https://nvie.com/posts/a-successful-git-branching-model/). In practice, this means that 
+the master branch contains the last production release of the schema whereas the develop branch 
+contains the latest development changes which will end up in the next production release. As of 
+February 2022,  the master branch contains the last production release (currently 
+![release_badge](https://img.shields.io/github/v/tag/ga4gh/tool-registry-service-schemas))) whereas 
+the develop branch contains work which will accumulate and evolve into a 2.1 production release.
 
 Our current iteration focuses on a read-only API due to potentially different views and approaches to registration/security.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ What is the Tool Registry API Schema?
 
 This is the home of the schema for the GA4GH Tool Registry API. The GA4GH Tool Registry API is a standard for listing and describing available tools (both stand-alone, self-contained tools and workflows in CWL, WDL, Nextflow, Galaxy or Snakemake) in a given registry. This defines a minimal, common API describing tools that we propose for support by multiple tool/workflow registries like [Dockstore](https://www.dockstore.org/), [BioContainers](https://biocontainers.pro), and [Agora](https://github.com/broadinstitute/agora) for the purposes of exchange, indexing, and searching.
 
-This repo uses the [HubFlow](https://github.com/mvalipour/hubflow) scheme which is closely based on 
+This repo uses the [HubFlow](https://github.com/dockstore/hubflow) scheme which is closely based on 
 [GitFlow](https://nvie.com/posts/a-successful-git-branching-model/). In practice, this means that 
 the master branch contains the last production release of the schema whereas the develop branch 
 contains the latest development changes which will end up in the next production release. As of 


### PR DESCRIPTION
The CI for #249 is currently [failing](https://github.com/ga4gh/tool-registry-service-schemas/actions/runs/9177866407) because of a broken link.

Point the URL to the [HubFlow repository](https://github.com/mvalipour/hubflow) rather than its documentation on GH Pages, which is (currently?) down.