### PR TITLE
ci: upgrade GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,21 +13,21 @@ jobs:
    checkLinks:
      runs-on: ubuntu-latest
      steps:
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@v4
      - name: Use Node.js
-       uses: actions/setup-node@v1
+       uses: actions/setup-node@v4
        with:
-         node-version: 14.x
+         node-version: 20.x
      - run: npm i -g markdown-link-check
      - run: markdown-link-check ./README.md
    buildPage:
      runs-on: ubuntu-latest
      steps:
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@v4
      - name: Use Node.js
-       uses: actions/setup-node@v1
+       uses: actions/setup-node@v4
        with:
-         node-version: 14.x
+         node-version: 20.x
      - run: npm ci
      - run: npx gh-openapi-docs
      - run: bash scripts/update-ghpages.sh

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -8,8 +8,8 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
-        uses: char0n/swagger-editor-validate@v1.2.1
+        uses: char0n/swagger-editor-validate@v1
         with:
           definition-file: openapi/openapi.yaml


### PR DESCRIPTION
To avoid the (deprecation) warnings issued for current PR runs (e.g., [this one](https://github.com/ga4gh/tool-registry-service-schemas/actions/runs/9178259260)), upgrade all used GitHub Actions to recent versions. Also, only the major version number was pinned for each action, thus reducing the need for more frequent patch or minor updates.

Specifically, upgrade the following Actions:

- [actions/checkout](https://github.com/actions/checkout) from v2 to **v4**
- [actions/setup-node](https://github.com/actions/setup-node) from v1 to **v4**; used `node-version` set to `20.x`, from currently `14.x`
- [char0n/swagger-editor-validate](https://github.com/char0n/swagger-editor-validate) from v1.2.1 to **v1** (will currently use 1.3.2)