### PR TITLE
Allow dependabot builds to manipulate gh-pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on: [push]
 env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+permissions:
+  pages: write
+  contents: write
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
    checkLinks:


### PR DESCRIPTION
Probably need this to allow dependabot builds to pass.
There are five older dependabot builds in https://github.com/ga4gh/tool-registry-service-schemas/pulls
Looks like they all fail on writing to gh-pages. Adding some permissions to allow them to pass.  

See also https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions