### PR TITLE
 Fixes #246

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -470,9 +470,8 @@ components:
         type: string
   securitySchemes:
     BEARER:
-      type: apiKey
-      name: Authorization
-      in: header
+      type: http
+      scheme: bearer
   schemas:
     Checksum:
       type: object


### PR DESCRIPTION
Fix BEARER security scheme to use native HTTP bearer auth

The security scheme was defined as apiKey type, a leftover from the Swagger 2.0 to OpenAPI 3.0 conversion. Update to the correct http/bearer type for accurate API docs and client codegen.